### PR TITLE
Feat/otp functionality

### DIFF
--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -1,0 +1,29 @@
+import User from '../models/user';
+import { generateOTP } from '../utils/otp';
+
+class UserService {
+    constructor() {}
+
+    static async updateUserOtp(user: any, id?: string)  {
+        const OTP_EXPIRATION = 10 * 60 * 1000; // 10 minutes
+        try {
+            if (id) {
+                const user = await User.findById(id);
+                if (!user) {
+                    throw new Error('User not found');
+                }
+            } else {
+                const otp = generateOTP();
+                const otpExpiration = Date.now() + OTP_EXPIRATION;
+                user.otp = otp;
+                user.otpExpires = otpExpiration;
+                await user.save();
+            }
+            return user;
+        } catch (error: any) {
+            throw new Error(`Error updating user: ${error.message}`);
+        }
+    }
+}
+
+export default UserService;

--- a/src/utils/otp.ts
+++ b/src/utils/otp.ts
@@ -1,0 +1,7 @@
+export function generateOTP(length: number = 6): number {
+  let otp = '';
+  for (let i = 0; i < length; i++) {
+    otp += Math.floor(Math.random() * 10).toString();
+  }
+  return parseInt(otp, 10);
+}


### PR DESCRIPTION
Close #3 

- Added functionality to generate a 6-digit numeric OTP and save it to the user’s document along with an expiry timestamp (e.g., 10 mins).

- Generates OTP

- Save otp and otpExpires fields

- Return success response (no email sending for now)

Sample:
![image](https://github.com/user-attachments/assets/bac66189-4e59-4022-bdd3-637b77467a50)


Trigger: Called after successful signup or via separate endpoint ( separate service for now)