### PR TITLE
feat: Implement Get Event Tickets by Category API Endpoint

### DIFF
--- a/src/controllers/event-ticket.controller.ts
+++ b/src/controllers/event-ticket.controller.ts
@@ -38,3 +38,43 @@ export const getEventTickets: RequestHandler = async (req, res) => {
         });
     }
 };
+
+export const getEventTicketsByCategory: RequestHandler = async (req, res) => {
+    try {
+        // Extract category from params and pagination from query
+        const category = req.params.category;
+        const page = parseInt(req.query.page as string) || 1;
+        const limit = 8;
+
+        // Validate category parameter
+        if (!category || category.trim() === '') {
+            return res.status(400).json({
+                error: 'Invalid category',
+                message: 'Category parameter is required'
+            });
+        }
+
+        // Validate pagination parameters
+        if (page < 1) {
+            return res.status(400).json({
+                error: 'Invalid page number',
+                message: 'Page number must be greater than 0'
+            });
+        }
+
+        // Fetch event tickets by category from service
+        const result = await EventTicketService.getEventTicketsByCategory(category, page, limit);
+
+        // Return success response
+        res.status(200).json(result);
+
+    } catch (error) {
+        console.error('Error fetching event tickets by category:', error);
+
+        // Return error response
+        res.status(500).json({
+            error: 'Internal server error',
+            message: error instanceof Error ? error.message : 'Failed to fetch event tickets by category'
+        });
+    }
+};

--- a/src/routes/event-ticket.route.ts
+++ b/src/routes/event-ticket.route.ts
@@ -1,9 +1,12 @@
 import { Router } from "express";
-import { getEventTickets } from "../controllers/event-ticket.controller";
+import { getEventTickets, getEventTicketsByCategory } from "../controllers/event-ticket.controller";
 
 const eventTicketRoutes = Router();
 
 // GET /api/event-tickets - Fetch paginated event tickets
 eventTicketRoutes.get('/', getEventTickets);
+
+// GET /api/event-tickets/category/:category - Fetch event tickets by category
+eventTicketRoutes.get('/category/:category', getEventTicketsByCategory);
 
 export default eventTicketRoutes;


### PR DESCRIPTION
- Add getEventTicketsByCategory service method with case-insensitive filtering
- Add controller method with proper validation and error handling
- Add GET /category/:category route for category-based ticket retrieval
- Support pagination with 8 items per page default
- Filter by eventCategory field using regex for case-insensitive matching
- Sort results by event date ascending