### PR TITLE
feat: centralized error handler with typed AppError hierarchy (#96)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -11,6 +11,7 @@ import mediaRoutes from './routes/media.route';
 import ticketOrderRoutes from './routes/ticket-order.route';
 import queueMonitorRoutes from './routes/queue-monitor.route';
 import zkEmailRoutes from './routes/zkemail.route';
+import { globalErrorHandler } from './middlewares/errorHandler';
 
 const app = express();
 
@@ -37,43 +38,6 @@ app.use('/api', queueMonitorRoutes);
 app.use('/zkemail', authLimiter, zkEmailRoutes);
 app.use(protectedRoute);
 
-app.use(
-  (
-    err: any,
-    req: express.Request,
-    res: express.Response,
-    next: express.NextFunction,
-  ) => {
-    if (err.status === 429) {
-      return res.status(429).json({
-        error: 'Too many requests',
-        message: err.message || 'Rate limit exceeded',
-        retryAfter: err.retryAfter || 60,
-      });
-    }
-
-    if (err.code === 'LIMIT_FILE_SIZE') {
-      return res.status(400).json({
-        error: 'Validation failed',
-        message: 'Image must be less than 5MB',
-      });
-    }
-
-    if (
-      err.message &&
-      /Unsupported file type|Invalid image type/.test(err.message)
-    ) {
-      return res.status(400).json({
-        error: 'Validation failed',
-        message: err.message,
-      });
-    }
-
-    console.error('Server error:', err);
-    res.status(err.status || 500).json({
-      error: 'Internal server error',
-    });
-  },
-);
+app.use(globalErrorHandler);
 
 export default app;

--- a/src/errors/AppError.ts
+++ b/src/errors/AppError.ts
@@ -1,0 +1,58 @@
+export class AppError extends Error {
+  readonly statusCode: number;
+  readonly code: string;
+  readonly isOperational: boolean;
+
+  constructor(message: string, statusCode: number, code: string) {
+    super(message);
+    this.statusCode = statusCode;
+    this.code = code;
+    this.isOperational = true;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(message = 'Resource not found') {
+    super(message, 404, 'NOT_FOUND');
+  }
+}
+
+export class ValidationError extends AppError {
+  readonly details?: unknown;
+
+  constructor(message: string, details?: unknown) {
+    super(message, 400, 'VALIDATION_ERROR');
+    this.details = details;
+  }
+}
+
+export class UnauthorizedError extends AppError {
+  constructor(message = 'Unauthorized') {
+    super(message, 401, 'UNAUTHORIZED');
+  }
+}
+
+export class ForbiddenError extends AppError {
+  constructor(message = 'Forbidden') {
+    super(message, 403, 'FORBIDDEN');
+  }
+}
+
+export class ConflictError extends AppError {
+  constructor(message: string) {
+    super(message, 409, 'CONFLICT');
+  }
+}
+
+export class PaymentVerificationError extends AppError {
+  constructor(message: string) {
+    super(message, 422, 'PAYMENT_VERIFICATION_FAILED');
+  }
+}
+
+export class ServiceUnavailableError extends AppError {
+  constructor(message = 'Service temporarily unavailable') {
+    super(message, 503, 'SERVICE_UNAVAILABLE');
+  }
+}

--- a/src/middlewares/errorHandler.ts
+++ b/src/middlewares/errorHandler.ts
@@ -1,0 +1,96 @@
+import { Request, Response, NextFunction } from 'express';
+import { ZodError } from 'zod';
+import { AppError, ValidationError } from '../errors/AppError';
+
+interface ErrorResponse {
+  status: number;
+  message: string;
+  code: string;
+  details?: unknown;
+  stack?: string;
+}
+
+export function globalErrorHandler(
+  err: unknown,
+  req: Request,
+  res: Response,
+  _next: NextFunction,
+): void {
+  const isDev = process.env.NODE_ENV === 'development';
+
+  // Zod validation errors
+  if (err instanceof ZodError) {
+    const details = err.errors.map((e) => ({
+      field: e.path.join('.'),
+      message: e.message,
+    }));
+    const body: ErrorResponse = {
+      status: 400,
+      message: 'Validation failed',
+      code: 'VALIDATION_ERROR',
+      details,
+    };
+    if (isDev) body.stack = new ValidationError('Validation failed').stack;
+    res.status(400).json(body);
+    return;
+  }
+
+  // Multer file-size error
+  if ((err as any)?.code === 'LIMIT_FILE_SIZE') {
+    res.status(400).json({
+      status: 400,
+      message: 'Image must be less than 5MB',
+      code: 'FILE_TOO_LARGE',
+    });
+    return;
+  }
+
+  // Rate-limit error (express-rate-limit sets status 429)
+  if ((err as any)?.status === 429) {
+    res.status(429).json({
+      status: 429,
+      message: (err as any).message || 'Rate limit exceeded',
+      code: 'RATE_LIMIT_EXCEEDED',
+      retryAfter: (err as any).retryAfter ?? 60,
+    });
+    return;
+  }
+
+  // Multer unsupported file type
+  if (
+    err instanceof Error &&
+    /Unsupported file type|Invalid image type/.test(err.message)
+  ) {
+    res.status(400).json({
+      status: 400,
+      message: err.message,
+      code: 'INVALID_FILE_TYPE',
+    });
+    return;
+  }
+
+  // Intentional AppError subclasses (safe to expose)
+  if (err instanceof AppError) {
+    const body: ErrorResponse = {
+      status: err.statusCode,
+      message: err.message,
+      code: err.code,
+    };
+    if ((err as any).details !== undefined) {
+      body.details = (err as any).details;
+    }
+    if (isDev) body.stack = err.stack;
+    res.status(err.statusCode).json(body);
+    return;
+  }
+
+  // Unhandled / unexpected error — log full details, send generic 500
+  console.error('[ErrorHandler] Unhandled error:', err);
+  const body: ErrorResponse = {
+    status: 500,
+    message: 'Internal server error',
+    code: 'INTERNAL_SERVER_ERROR',
+  };
+  if (isDev && err instanceof Error) body.stack = err.stack;
+  res.status(500).json(body);
+}


### PR DESCRIPTION
## Summary

- New `src/errors/AppError.ts`: typed error class hierarchy — `AppError` base plus `NotFoundError`, `ValidationError`, `UnauthorizedError`, `ForbiddenError`, `ConflictError`, `PaymentVerificationError`, `ServiceUnavailableError`
- New `src/middlewares/errorHandler.ts`: `globalErrorHandler` Express middleware handles ZodError (400 with field details), multer limits, rate-limit 429, AppError subclasses, and unknown errors (500). Dev mode adds stack trace.
- `src/app.ts`: replaced inline error handler with `app.use(globalErrorHandler)`

## Test plan

- [ ] Throwing `NotFoundError` returns 404 with `code: NOT_FOUND`
- [ ] Zod parse failure returns 400 with `errors` array
- [ ] Unknown error returns 500 without leaking stack in production
- [ ] Stack trace present in `NODE_ENV=development` response

Closes #96

Generated with Claude Code