### PR TITLE
Add duplicate payment prevention with idempotency keys

### DIFF
--- a/src/controllers/ticket-order.controller.ts
+++ b/src/controllers/ticket-order.controller.ts
@@ -2,6 +2,7 @@ import { RequestHandler } from 'express';
 import { TicketOrderService } from '../services/ticket-order.service';
 import { PaymentVerificationService } from '../verification/payment-verification.service';
 import { UserAuthenticatedReq } from '../utils/types';
+import { getIdempotencyKey } from '../middlewares/idempotency';
 
 /**
  * Controller for Ticket Orders and Payments transparency
@@ -146,6 +147,7 @@ export const verifyPayment: RequestHandler = async (
     }
 
     // ── Payment verification ──────────────────────────────────────────────────
+    const idempotencyKey = getIdempotencyKey(req);
     const result = await PaymentVerificationService.verifyAndIssueTicket(
       txHash.trim(),
       userId.toString(),
@@ -153,6 +155,7 @@ export const verifyPayment: RequestHandler = async (
       ticketType,
       parsedQty,
       parsedAmount,
+      idempotencyKey,
     );
 
     if (!result.success) {
@@ -165,6 +168,7 @@ export const verifyPayment: RequestHandler = async (
     res.status(200).json({
       success: true,
       message: result.message,
+      isRetry: result.isRetry,
       data: {
         transactionId: result.transactionId,
         orderId: result.orderId,

--- a/src/middlewares/idempotency.ts
+++ b/src/middlewares/idempotency.ts
@@ -1,0 +1,51 @@
+import { RequestHandler } from 'express';
+import { v4 as uuidv4 } from 'uuid';
+
+/**
+ * Idempotency Middleware
+ *
+ * Extracts or generates an idempotency key from request headers.
+ * The key is attached to req.body for later use in duplicate detection.
+ *
+ * Clients should send: Idempotency-Key: <uuid>
+ * If not provided, one will be generated (for non-idempotent operations, this still helps with deduplication).
+ *
+ * Reference: https://stripe.com/docs/api/idempotent_requests
+ */
+
+export interface IdempotentRequest extends Express.Request {
+  idempotencyKey?: string;
+}
+
+export const idempotencyMiddleware: RequestHandler = (req, res, next) => {
+  // Extract idempotency key from header (case-insensitive)
+  let key = (req.headers['idempotency-key'] as string)?.trim();
+
+  // If not provided, generate one for tracking
+  if (!key) {
+    key = uuidv4();
+  }
+
+  // Validate format (should be a valid UUID or similar)
+  if (!/^[a-f0-9-]{36}$|^[\w-]{20,}$/.test(key)) {
+    return res.status(400).json({
+      error: 'Invalid Idempotency-Key format',
+      message: 'Idempotency-Key must be a valid UUID or alphanumeric string',
+    });
+  }
+
+  // Attach to request for downstream handlers
+  (req as IdempotentRequest).idempotencyKey = key;
+
+  // For safety, include in response headers so client can track
+  res.setHeader('Idempotency-Key', key);
+
+  next();
+};
+
+/**
+ * Extract idempotency key from request
+ */
+export function getIdempotencyKey(req: any): string {
+  return req.idempotencyKey || (req.headers['idempotency-key'] as string) || '';
+}

--- a/src/models/ticket-order.ts
+++ b/src/models/ticket-order.ts
@@ -16,6 +16,7 @@ export interface ITicketOrder extends Document {
   privacyLevel: string;
   hasReceipt: boolean;
   datePurchased: Date;
+  idempotencyKey?: string; // unique idempotency key for duplicate prevention
 }
 
 const ticketOrderSchema = new Schema<ITicketOrder>(
@@ -40,6 +41,7 @@ const ticketOrderSchema = new Schema<ITicketOrder>(
     privacyLevel: { type: String, required: true },
     hasReceipt: { type: Boolean, default: false },
     datePurchased: { type: Date, default: Date.now },
+    idempotencyKey: { type: String, sparse: true, unique: true },
   },
   { timestamps: true },
 );

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -7,6 +7,7 @@ export interface ITransaction extends Document {
   transactionDate: Date; // date of the transaction
   status: string; // e.g., pending, completed, failed
   transactionId: string; // unique identifier from service gateway
+  idempotencyKey?: string; // unique idempotency key for safe retries
 }
 
 const transactionSchema = new Schema<ITransaction>(
@@ -26,9 +27,13 @@ const transactionSchema = new Schema<ITransaction>(
       default: 'pending',
     },
     transactionId: { type: String, required: true, unique: true },
+    idempotencyKey: { type: String, sparse: true, unique: true },
   },
   { timestamps: true },
 );
+
+// Compound index for duplicate detection: (user + eventTicket + transactionId)
+transactionSchema.index({ user: 1, eventTicket: 1, transactionId: 1 }, { unique: true });
 
 const Transaction = mongoose.model<ITransaction>(
   'Transaction',

--- a/src/utils/idempotency.ts
+++ b/src/utils/idempotency.ts
@@ -1,0 +1,61 @@
+/**
+ * Duplicate Payment Prevention Utilities
+ *
+ * Provides functions for handling idempotency keys, duplicate detection,
+ * and safe retry mechanisms for payment processing.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { createHash } from 'crypto';
+
+/**
+ * Generate a deterministic idempotency key from payment details
+ * Used for webhook events where a client-provided key doesn't exist
+ */
+export function generateDeterministicKey(
+  txHash: string,
+  userId: string,
+  eventTicketId: string,
+  amount: number,
+): string {
+  // Create a deterministic hash from payment details
+  const input = `${txHash}:${userId}:${eventTicketId}:${amount}`;
+  return createHash('sha256').update(input).digest('hex').slice(0, 32);
+}
+
+/**
+ * Validate idempotency key format
+ * Accepts UUID or 32-char hex strings
+ */
+export function isValidIdempotencyKey(key: string): boolean {
+  if (!key) return false;
+  // UUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  // Or hex string: 32 character hex
+  const uuidRegex = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
+  const hexRegex = /^[a-f0-9]{32}$/i;
+  return uuidRegex.test(key) || hexRegex.test(key);
+}
+
+/**
+ * Create a duplicate prevention response
+ * Indicates that a request was a retry of a successful payment
+ */
+export interface DuplicatePaymentResponse {
+  isDuplicate: true;
+  transactionId: string;
+  orderId?: string;
+  message: string;
+  timestamp: Date;
+}
+
+/**
+ * Attempt to extract user ID from various request contexts
+ */
+export function extractUserId(
+  req: any,
+): string | null {
+  return req.user?._id ||
+    (req.user as any)?.id ||
+    req.userId ||
+    null;
+}

--- a/src/verification/payment-verification.service.ts
+++ b/src/verification/payment-verification.service.ts
@@ -20,11 +20,13 @@ export interface VerificationResult {
   transactionId?: string;
   orderId?: string;
   message: string;
+  isRetry?: boolean; // indicates if this was a retry of a successful payment
 }
 
 export class PaymentVerificationService {
   /**
    * Verify an on-chain transaction and issue a ticket if everything checks out.
+   * Supports idempotency for safe retries.
    *
    * @param txHash             Blockchain transaction hash submitted by the user
    * @param userId             Authenticated user's MongoDB ID
@@ -32,6 +34,7 @@ export class PaymentVerificationService {
    * @param ticketType         e.g. "VIP", "General"
    * @param quantity           Number of tickets requested
    * @param expectedAmountUsd  Amount we expect to have been paid (stored in DB)
+   * @param idempotencyKey     Optional idempotency key for duplicate prevention
    */
   static async verifyAndIssueTicket(
     txHash: string,
@@ -40,14 +43,38 @@ export class PaymentVerificationService {
     ticketType: string,
     quantity: number,
     expectedAmountUsd: number,
+    idempotencyKey?: string,
   ): Promise<VerificationResult> {
-    // ── 1. Replay guard ───────────────────────────────────────────────────────
-    const existing = await Transaction.findOne({ transactionId: txHash });
-    if (existing) {
-      return { success: false, message: 'Transaction already processed' };
+    // ── 1. Idempotency guard: check if this request was already processed ─────
+    if (idempotencyKey) {
+      const existingByKey = await Transaction.findOne({ idempotencyKey });
+      if (existingByKey) {
+        // Same idempotency key was used before — return the cached result
+        const order = await TicketOrder.findOne({
+          idempotencyKey,
+        });
+        return {
+          success: true,
+          transactionId: (existingByKey._id as any).toString(),
+          orderId: (order?._id as any).toString(),
+          message: 'Payment already verified for this request (idempotency match)',
+          isRetry: true,
+        };
+      }
     }
 
-    // ── 2. Event existence + availability ────────────────────────────────────
+    // ── 2. Replay guard: check by txHash ──────────────────────────────────────
+    const existing = await Transaction.findOne({ transactionId: txHash });
+    if (existing) {
+      // Warn: txHash was already processed but with a different idempotency key
+      // This could indicate an attack or network retry. Still reject to prevent double charge.
+      return {
+        success: false,
+        message: 'Transaction already processed (txHash replay detected)',
+      };
+    }
+
+    // ── 3. Event existence + availability ────────────────────────────────────
     const event = await EventTicket.findById(eventTicketId);
     if (!event) {
       return { success: false, message: 'Event not found' };
@@ -82,7 +109,7 @@ export class PaymentVerificationService {
       }
     }
 
-    // ── 3. On-chain verification ──────────────────────────────────────────────
+    // ── 4. On-chain verification ──────────────────────────────────────────────
     const blockchain = BlockchainProvider.getInstance();
     const chainTx = await blockchain.fetchTransaction(txHash);
 
@@ -116,12 +143,12 @@ export class PaymentVerificationService {
       };
     }
 
-    // ── 4. Atomic DB writes ───────────────────────────────────────────────────
+    // ── 5. Atomic DB writes ───────────────────────────────────────────────────
     const session = await mongoose.startSession();
     session.startTransaction();
 
     try {
-      // Create completed transaction record
+      // Create completed transaction record with idempotency key
       const [transaction] = await Transaction.create(
         [
           {
@@ -131,12 +158,13 @@ export class PaymentVerificationService {
             transactionDate: new Date(),
             status: 'completed',
             transactionId: txHash,
+            idempotencyKey: idempotencyKey || undefined,
           },
         ],
         { session },
       );
 
-      // Create completed ticket order
+      // Create completed ticket order with idempotency key
       const [order] = await TicketOrder.create(
         [
           {
@@ -151,6 +179,7 @@ export class PaymentVerificationService {
             privacyLevel: String(event.privacyLevel),
             hasReceipt: event.offerReceipts ?? false,
             datePurchased: new Date(),
+            idempotencyKey: idempotencyKey || undefined,
           },
         ],
         { session },

--- a/tests/payment-duplicate-prevention.test.ts
+++ b/tests/payment-duplicate-prevention.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import mongoose from 'mongoose';
+import Transaction from '../models/transaction';
+import TicketOrder from '../models/ticket-order';
+import EventTicket from '../models/event-ticket';
+import User from '../models/user';
+import { PaymentVerificationService } from '../verification/payment-verification.service';
+
+/**
+ * Duplicate Payment Prevention Tests
+ *
+ * These tests verify that the system properly prevents:
+ * 1. No double charges (same txHash rejected)
+ * 2. Safe retries with idempotency keys (same key returns cached result)
+ * 3. Compound uniqueness (user + event + transaction)
+ */
+
+describe('Duplicate Payment Prevention', () => {
+  let testUserId: string;
+  let testEventTicketId: string;
+  const testTxHash = '0x' + 'a'.repeat(64); // Mock tx hash
+  const testAmount = 100;
+
+  beforeAll(async () => {
+    // Create test user
+    const user = new User({
+      email: 'test-duplicate@example.com',
+      walletAddress: '0x' + '1'.repeat(40),
+      emailVerifiedAt: new Date(),
+    });
+    await user.save();
+    testUserId = user._id.toString();
+
+    // Create test event
+    const event = new EventTicket({
+      name: 'Duplicate Prevention Test Event',
+      date: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      location: 'Test Location',
+      description: 'Test event for duplicate prevention',
+      organizer: testUserId,
+      availableTickets: 100,
+      soldTickets: 0,
+      totalTickets: 100,
+      ticketTypes: ['General', 'VIP'],
+      privacyLevel: 'public',
+      allowAnonymous: true,
+      requiresVerification: false,
+      offerReceipts: true,
+    });
+    await event.save();
+    testEventTicketId = event._id.toString();
+  });
+
+  afterAll(async () => {
+    // Cleanup
+    await User.deleteMany({ email: 'test-duplicate@example.com' });
+    await EventTicket.deleteMany({
+      name: 'Duplicate Prevention Test Event',
+    });
+    await Transaction.deleteMany({ transactionId: testTxHash });
+    await TicketOrder.deleteMany({});
+  });
+
+  describe('Replay Attack Prevention (txHash)', () => {
+    it('should reject duplicate txHash on second attempt without idempotency key', async () => {
+      // First attempt - should succeed
+      const result1 = await PaymentVerificationService.verifyAndIssueTicket(
+        testTxHash,
+        testUserId,
+        testEventTicketId,
+        'General',
+        1,
+        testAmount,
+      );
+
+      expect(result1.success).toBe(true);
+      expect(result1.transactionId).toBeDefined();
+
+      // Second attempt with same txHash - should fail
+      const result2 = await PaymentVerificationService.verifyAndIssueTicket(
+        testTxHash,
+        testUserId,
+        testEventTicketId,
+        'General',
+        1,
+        testAmount,
+      );
+
+      expect(result2.success).toBe(false);
+      expect(result2.message).toContain('replay');
+    });
+  });
+
+  describe('Idempotency Key Support (Safe Retries)', () => {
+    it('should return cached result on retry with same idempotency key', async () => {
+      const idempotencyKey = '550e8400-e29b-41d4-a716-446655440001';
+      const uniqueTxHash = '0x' + 'b'.repeat(64);
+
+      // First attempt
+      const result1 = await PaymentVerificationService.verifyAndIssueTicket(
+        uniqueTxHash,
+        testUserId,
+        testEventTicketId,
+        'VIP',
+        2,
+        testAmount,
+        idempotencyKey,
+      );
+
+      expect(result1.success).toBe(true);
+      const transactionId1 = result1.transactionId;
+
+      // Retry with same idempotency key - should get same result
+      const result2 = await PaymentVerificationService.verifyAndIssueTicket(
+        uniqueTxHash,
+        testUserId,
+        testEventTicketId,
+        'VIP',
+        2,
+        testAmount,
+        idempotencyKey,
+      );
+
+      expect(result2.success).toBe(true);
+      expect(result2.transactionId).toBe(transactionId1);
+      expect(result2.isRetry).toBe(true);
+      expect(result2.message).toContain('idempotency match');
+    });
+
+    it('should reject different idempotency key with same txHash', async () => {
+      const uniqueTxHash = '0x' + 'c'.repeat(64);
+      const idempotencyKey1 = '550e8400-e29b-41d4-a716-446655440002';
+      const idempotencyKey2 = '550e8400-e29b-41d4-a716-446655440003';
+
+      // First request with key1
+      const result1 = await PaymentVerificationService.verifyAndIssueTicket(
+        uniqueTxHash,
+        testUserId,
+        testEventTicketId,
+        'General',
+        1,
+        testAmount,
+        idempotencyKey1,
+      );
+
+      expect(result1.success).toBe(true);
+
+      // Second request with different key but same txHash - should fail
+      const result2 = await PaymentVerificationService.verifyAndIssueTicket(
+        uniqueTxHash,
+        testUserId,
+        testEventTicketId,
+        'General',
+        1,
+        testAmount,
+        idempotencyKey2,
+      );
+
+      expect(result2.success).toBe(false);
+      expect(result2.message).toContain('replay detected');
+    });
+  });
+
+  describe('Uniqueness Constraints', () => {
+    it('should enforce unique transaction idempotency key', async () => {
+      const idempotencyKey = '550e8400-e29b-41d4-a716-446655440004';
+      const txHash1 = '0x' + 'd'.repeat(64);
+
+      // First payment
+      const result1 = await PaymentVerificationService.verifyAndIssueTicket(
+        txHash1,
+        testUserId,
+        testEventTicketId,
+        'General',
+        1,
+        testAmount,
+        idempotencyKey,
+      );
+
+      expect(result1.success).toBe(true);
+
+      // Attempting to use same idempotency key with different txHash should fail
+      const txHash2 = '0x' + 'e'.repeat(64);
+      const result2 = await PaymentVerificationService.verifyAndIssueTicket(
+        txHash2,
+        testUserId,
+        testEventTicketId,
+        'General',
+        1,
+        testAmount,
+        idempotencyKey,
+      );
+
+      // Should return cached result from first payment (idempotency semantics)
+      expect(result2.success).toBe(true);
+      expect(result2.isRetry).toBe(true);
+    });
+  });
+
+  describe('No Double Charges', () => {
+    it('should only charge once even with multiple webhook deliveries', async () => {
+      const txHash = '0x' + 'f'.repeat(64);
+      const idempotencyKey = '550e8400-e29b-41d4-a716-446655440005';
+
+      // First webhook delivery
+      const result1 = await PaymentVerificationService.verifyAndIssueTicket(
+        txHash,
+        testUserId,
+        testEventTicketId,
+        'General',
+        1,
+        testAmount,
+        idempotencyKey,
+      );
+
+      expect(result1.success).toBe(true);
+
+      // Simulate webhook retry
+      const result2 = await PaymentVerificationService.verifyAndIssueTicket(
+        txHash,
+        testUserId,
+        testEventTicketId,
+        'General',
+        1,
+        testAmount,
+        idempotencyKey,
+      );
+
+      expect(result2.success).toBe(true);
+      expect(result2.transactionId).toBe(result1.transactionId);
+
+      // Verify only one transaction was created
+      const transactions = await Transaction.find({ transactionId: txHash });
+      expect(transactions).toHaveLength(1);
+
+      // Verify only one ticket order was created
+      const orders = await TicketOrder.find({ idempotencyKey });
+      expect(orders).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
## Prevent Duplicate Payments
close #74
### Description
Implements idempotency-based duplicate payment prevention to ensure no double charges and enable safe retries.

### Changes
- Added `idempotencyKey` field to Transaction and TicketOrder models with unique indexes
- Created idempotency middleware to extract/validate `Idempotency-Key` headers
- Enhanced PaymentVerificationService with idempotency checks and replay attack protection
- Added comprehensive test suite for duplicate prevention scenarios

### How to Test
1. Send payment request with `Idempotency-Key: <uuid>` header → succeeds
2. Retry with same key → returns cached result without re-charging
3. Retry with different key but same txHash → rejected (replay protection)

### Acceptance Criteria ✅
- [x] No double charges
- [x] Unique reference (idempotency keys)
- [x] Reject duplicates
- [x] Safe retries

### Related Files
- `src/middlewares/idempotency.ts` - Middleware for key extraction
- `src/models/transaction.ts` & `ticket-order.ts` - Model updates
- `src/verification/payment-verification.service.ts` - Enhanced verification logic
- `tests/payment-duplicate-prevention.test.ts` - Test suite


### Deployment Notes
- Requires database migration to create indexes
- Add middleware to payment routes: `app.use(idempotencyMiddleware)`
- No breaking changes to existing API