### PR TITLE
feat: validate required env variables at startup

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -2,6 +2,27 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
+const REQUIRED_ENV_VARS = [
+  'MONGO_URI',
+  'JWT_SECRET',
+  'GOOGLE_CLIENT_ID',
+  'GOOGLE_CLIENT_SECRET',
+  'GOOGLE_CALLBACK_URL',
+  'FRONTEND_URL',
+  'EMAIL_USER',
+  'EMAIL_PASSWORD',
+  'CLOUDINARY_CLOUD_NAME',
+  'CLOUDINARY_API_KEY',
+  'CLOUDINARY_API_SECRET',
+] as const;
+
+export function validateEnv(): void {
+  const missing = REQUIRED_ENV_VARS.filter((key) => !process.env[key]);
+  if (missing.length > 0) {
+    throw new Error(`Missing required environment variables: ${missing.join(', ')}`);
+  }
+}
+
 interface Config {
   port: number;
   nodeEnv: string;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 import app from './app';
-import config from './config/config';
+import config, { validateEnv } from './config/config';
 import { mongoConnect } from './config/db.mongo';
 import queueService from './services/queue.service';
 import emailWorker from './workers/email.worker';
@@ -7,6 +7,9 @@ import zkEmailWorker from './workers/zkemail.worker';
 
 async function startServer() {
   try {
+    // Validate required environment variables
+    validateEnv();
+
     // Connect to MongoDB
     await mongoConnect();
     console.log('✓ MongoDB connected');


### PR DESCRIPTION
 Validate environment variables at startup
  
  Adds a validateEnv() function that checks all required env vars before any
  service initializes. If any are missing, the process exits immediately with a
  clear error listing what's absent — rather than failing silently mid-startup
  (e.g. during DB connect or queue init).
  
  Changes
  
  - src/config/config.ts — added validateEnv() with a list of required keys
  - src/server.ts — calls validateEnv() as the first step in startServer()
  
  Example error on missing vars:
  
  Error: Missing required environment variables: MONGO_URI, JWT_SECRET
 closes #95