### PR TITLE
fix(auth): enforce email verification at the protected-route guard (#122)

### DIFF
--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -17,6 +17,16 @@ const authGuard = async (req: UserAuthenticatedReq, res: any, next: any) => {
 
     const user = await validateAndGetUser(token);
 
+    // Defense in depth: a valid JWT is not enough. Local accounts must have a
+    // verified email before reaching any protected route (see issue #122).
+    // Google accounts are verified by the provider and carry emailVerifiedAt.
+    if (user.provider === 'local' && !user.emailVerifiedAt) {
+      return res.status(403).json({
+        error:
+          'Forbidden: Please verify your email before accessing this resource',
+      });
+    }
+
     req.user = user;
     return next();
   } catch (err) {

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -8,7 +8,7 @@ const extractToken = (req: any): string | null => {
 
 const validateAndGetUser = async (token: string) => {
   const decoded = JwtVerify(token);
-  const user = await User.findOne({ id: decoded.id });
+  const user = await User.findById(decoded.id);
 
   if (!user) {
     throw new Error('Token is blacklisted');

--- a/tests/auth.middleware.test.ts
+++ b/tests/auth.middleware.test.ts
@@ -1,0 +1,103 @@
+import { authGuard } from '../src/middlewares/auth';
+import User from '../src/models/user';
+import { JwtVerify } from '../src/middlewares/jwt';
+
+jest.mock('../src/models/user');
+jest.mock('../src/middlewares/jwt');
+
+// Regression coverage for issue #122: a valid JWT alone must not grant access to
+// protected routes. Unverified local accounts have to be blocked at the guard,
+// not only at the login controller.
+describe('authGuard middleware — email verification enforcement (issue #122)', () => {
+  const createResponse = () => ({
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  });
+
+  const createRequest = () => ({
+    headers: { authorization: 'Bearer valid.jwt.token' },
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (JwtVerify as jest.Mock).mockReturnValue({
+      id: 'user-id-1',
+      email: 'user@example.com',
+    });
+  });
+
+  it('blocks an unverified local account from reaching a protected route (403)', async () => {
+    (User.findById as jest.Mock).mockResolvedValue({
+      _id: 'user-id-1',
+      email: 'user@example.com',
+      provider: 'local',
+      emailVerifiedAt: undefined,
+    });
+
+    const req = createRequest();
+    const res = createResponse();
+    const next = jest.fn();
+
+    await authGuard(req as any, res as any, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      error:
+        'Forbidden: Please verify your email before accessing this resource',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('allows a verified local account through to the protected route', async () => {
+    const verifiedUser = {
+      _id: 'user-id-1',
+      email: 'user@example.com',
+      provider: 'local',
+      emailVerifiedAt: new Date(),
+    };
+    (User.findById as jest.Mock).mockResolvedValue(verifiedUser);
+
+    const req = createRequest();
+    const res = createResponse();
+    const next = jest.fn();
+
+    await authGuard(req as any, res as any, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+    expect((req as any).user).toBe(verifiedUser);
+  });
+
+  it('allows a Google account through even without emailVerifiedAt set', async () => {
+    (User.findById as jest.Mock).mockResolvedValue({
+      _id: 'user-id-1',
+      email: 'user@example.com',
+      provider: 'google',
+      emailVerifiedAt: undefined,
+    });
+
+    const req = createRequest();
+    const res = createResponse();
+    const next = jest.fn();
+
+    await authGuard(req as any, res as any, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('rejects a request with no token before any verification check (401)', async () => {
+    const req = { headers: {} };
+    const res = createResponse();
+    const next = jest.fn();
+
+    await authGuard(req as any, res as any, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Unauthorized: No token provided',
+    });
+    expect(next).not.toHaveBeenCalled();
+    expect(User.findById).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #122

## Audit result

**Issue #51 ("Missing Local Account Verification Logic") was genuinely implemented** by PR #61 — this is not a "#84-style" no-op:

- `signup.controller.ts` generates an OTP, stores `otp`/`otpExpires`, and does **not** issue a token.
- `verify.controller.ts` (`POST /auth/verify-account`) validates the OTP and sets `emailVerifiedAt`.
- `login.controller.ts` rejects unverified local accounts with `403` (`if (!user.emailVerifiedAt)`).

So #51 does **not** need to be reopened — its acceptance criteria were met.

## The remaining gap (what #122 targets)

Verification was enforced **only at login**. The `authGuard` middleware — used by `/protected`, `zk-message-center`, `event-tickets` (scan/validate), `media`, and `ticket-orders` — passed any request with a valid JWT straight through. `validateAndGetUser` only verified the JWT signature and loaded the user; it never re-checked `emailVerifiedAt`.

Result: the invariant *"unverified local accounts cannot reach protected routes"* was guaranteed in a single place (the login controller) rather than at the gate that actually fronts the protected routes.

While auditing the guard I also found a latent bug: `validateAndGetUser` looked the user up with `User.findOne({ id: decoded.id })`. In Mongoose `id` is a non-queryable virtual, so that filter never matches `_id` and user lookup is effectively broken in production.

## Changes

1. **`src/middlewares/auth.ts`** — defense in depth: after loading the user, reject local accounts without `emailVerifiedAt` (`403`). This protects every guarded route at once. Google accounts are verified by the provider (they always carry `emailVerifiedAt`) and pass through.
2. **`src/utils/helper.ts`** — replace `User.findOne({ id: decoded.id })` with `User.findById(decoded.id)` so the guard can actually load the authenticated user.
3. **`tests/auth.middleware.test.ts`** — regression coverage:
   - unverified local account + valid JWT → `403`, `next()` not called (the key regression test);
   - verified local account → passes;
   - Google account → passes;
   - missing token → `401`.

## Verification

- `npm run build` (tsc) passes.
- New suite passes (`tests/auth.middleware.test.ts`), and existing `signup`/`verify` suites stay green.
- Genuineness check: temporarily disabling the new guard makes the "unverified local account → 403" test fail, confirming it is a real regression test rather than a tautology.

The changes are surgical — no refactors, no behavior changes to the magic-link or Google flows (both already set `emailVerifiedAt`).