### PR TITLE
fix: proportional cancellation reconciliation (withdrawable_ratio_bps)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,7 @@ REDIS_PASSWORD=
 # ── Reconciliation ────────────────────────────────────────────────────────────
 RECONCILIATION_STALE_MINUTES=30
 RECONCILIATION_CRON=*/15 * * * *
+# ── Soroban / Payments contract (proportional cancellation reads) ─────────────
+SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+PAYMENTS_CONTRACT_ID=C...
+SOROBAN_NETWORK_PASSPHRASE=Test SDF Network ; September 2015

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@stellar/stellar-sdk": "^16.0.1",
         "@types/passport-google-oauth20": "^2.0.17",
         "@zk-email/helpers": "^6.4.2",
         "bcrypt": "^6.0.0",
@@ -1819,6 +1820,15 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@noble/ed25519": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-3.1.0.tgz",
+      "integrity": "sha512-pfcObRY3CtvwfaG9Mt5XqZdKmAQppl37tHUeuBhDUbiwJBCVY4/A4lbMvb1xKhMDx96AqAqZpMWuBX1HulhX4g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
@@ -1934,6 +1944,54 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@stellar/js-xdr": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-4.0.0.tgz",
+      "integrity": "sha512-+NmNa7Tk5BI5XFdy/6xGTqAN4J9a9KgCrCGhj2uEUTCBhLkch0M+QbKzNH8zEnejWe0p8w+0q5hUVX6L3OzoVA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0",
+        "pnpm": ">=9.0.0"
+      }
+    },
+    "node_modules/@stellar/stellar-sdk": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-16.0.1.tgz",
+      "integrity": "sha512-bxKohaiyKVqoudRhbOOHeHhHIaeYV5Zab4rCjxhP4Ty1h1ozTLBOv8lWFnZz9ilBzXG8Bb7usQI3rlEcfvUynA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/ed25519": "^3.1.0",
+        "@noble/hashes": "^2.2.0",
+        "@stellar/js-xdr": "4.0.0",
+        "axios": "1.16.1",
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^11.1.1",
+        "buffer": "^6.0.3",
+        "commander": "^14.0.3",
+        "eventsource": "^4.1.0",
+        "feaxios": "^0.0.23",
+        "smol-toml": "^1.6.1",
+        "uint8array-extras": "^1.5.0"
+      },
+      "bin": {
+        "stellar-js": "bin/stellar-js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@stellar/stellar-sdk/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -2465,6 +2523,18 @@
       "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
       "license": "MIT"
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -2560,7 +2630,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/atob": {
@@ -2573,6 +2642,18 @@
       },
       "engines": {
         "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/b4a": {
@@ -2711,6 +2792,35 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base32.js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
+      "integrity": "sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/base64url": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
@@ -2768,6 +2878,12 @@
       "engines": {
         "node": ">= 8.0.0"
       }
+    },
+    "node_modules/bignumber.js": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-11.1.4.tgz",
+      "integrity": "sha512-AJ9dSeaUGj2xu7tEwmdqb51dqdb633xo4njI9K8ZFfcLrNr0XN8/EPkkZUNaF9fkCblGt2zVwZymesUdGynEkQ==",
+      "license": "MIT"
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -2951,6 +3067,30 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.20.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -3323,13 +3463,21 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/component-emitter": {
@@ -3520,7 +3668,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -3761,7 +3908,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3921,6 +4067,27 @@
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "license": "MIT"
     },
+    "node_modules/eventsource": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-4.1.0.tgz",
+      "integrity": "sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -4062,6 +4229,15 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/feaxios": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.23.tgz",
+      "integrity": "sha512-eghR0A21fvbkcQBgZuMfQhrXxJzC0GNUGC9fXhBge33D+mFDTwl0aJ35zoQQn575BhyjQitRc5N4f+L4cP708g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-retry-allowed": "^3.0.0"
+      }
+    },
     "node_modules/ffjavascript": {
       "version": "0.2.63",
       "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.63.tgz",
@@ -4150,11 +4326,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -4171,7 +4366,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4181,7 +4375,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -4436,7 +4629,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -4517,6 +4709,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -4542,6 +4747,26 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
@@ -4735,6 +4960,18 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
+      "integrity": "sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -6762,6 +6999,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -7258,6 +7504,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
+      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/snarkjs": {
@@ -7792,6 +8050,18 @@
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
       "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA==",
       "license": "MIT"
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/undefsafe": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/BuidlZone-Labs/zicket-backend#readme",
   "dependencies": {
+    "@stellar/stellar-sdk": "^16.0.1",
     "@types/passport-google-oauth20": "^2.0.17",
     "@zk-email/helpers": "^6.4.2",
     "bcrypt": "^6.0.0",

--- a/src/controllers/organizer-balance.controller.ts
+++ b/src/controllers/organizer-balance.controller.ts
@@ -1,0 +1,67 @@
+import { RequestHandler } from 'express';
+import EventTicket from '../models/event-ticket';
+import { OrganizerBalanceService } from '../services/organizer-balance.service';
+import { UserAuthenticatedReq } from '../utils/types';
+
+/**
+ * GET /event-tickets/:eventId/organizer-balance
+ * Returns proportional withdrawable/refund amounts sourced from contract storage.
+ */
+export const getOrganizerBalance: RequestHandler = async (
+  req: UserAuthenticatedReq,
+  res,
+) => {
+  try {
+    const userId = req.user?._id || (req.user as { id?: string })?.id;
+    const { eventId } = req.params;
+
+    if (!userId) {
+      return res.status(401).json({
+        error: 'Unauthorized',
+        message: 'User authentication required',
+      });
+    }
+
+    const event = await EventTicket.findById(eventId).lean();
+
+    if (!event) {
+      return res.status(404).json({
+        error: 'Not found',
+        message: 'Event not found',
+      });
+    }
+
+    if (event.organizedBy.toString() !== userId.toString()) {
+      return res.status(403).json({
+        error: 'Forbidden',
+        message: 'Only the event organizer can view this balance',
+      });
+    }
+
+    if (!event.onChainEventId) {
+      return res.status(400).json({
+        error: 'Not configured',
+        message: 'Event has no on-chain identifier linked',
+      });
+    }
+
+    const balance = await OrganizerBalanceService.getOrganizerBalanceForEvent(
+      event.onChainEventId,
+      event.eventStatus,
+    );
+
+    return res.status(200).json({
+      success: true,
+      data: balance,
+    });
+  } catch (error) {
+    console.error('Error fetching organizer balance:', error);
+    return res.status(500).json({
+      error: 'Internal server error',
+      message:
+        error instanceof Error
+          ? error.message
+          : 'Failed to fetch organizer balance',
+    });
+  }
+};

--- a/src/models/event-ticket.ts
+++ b/src/models/event-ticket.ts
@@ -20,6 +20,12 @@ export interface IEventTicket extends Document {
   availableTickets: number; // number of tickets still available
   soldTickets: number; // number of tickets sold
   eventStatus: string; // upcoming, ongoing, completed, cancelled
+  /** Soroban Symbol for the linked on-chain event (payments contract). */
+  onChainEventId?: string;
+  /** Synced from contract storage — never derived off-chain. */
+  withdrawableRatioBps?: number | null;
+  cancelLedger?: number | null;
+  organizerWithdrawn?: boolean;
   imageUrl: string; // image representing the event (Cloudinary URL)
   cloudinary_public_id?: string; // Cloudinary public ID for invalidation/destroy (required for new tickets)
   tags: string[]; // tags for better searchability
@@ -64,6 +70,10 @@ const eventTicketSchema = new Schema<IEventTicket>(
       enum: ['upcoming', 'ongoing', 'completed', 'cancelled'],
       default: 'upcoming',
     },
+    onChainEventId: { type: String, sparse: true, index: true },
+    withdrawableRatioBps: { type: Number, default: null },
+    cancelLedger: { type: Number, default: null },
+    organizerWithdrawn: { type: Boolean, default: false },
     imageUrl: { type: String, required: true },
     cloudinary_public_id: { type: String, required: false },
     tags: [{ type: String }],

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -11,6 +11,8 @@ export interface ITransaction extends Document {
    * Terminal states (confirmed, failed) cannot be overwritten.
    */
   status: 'pending' | 'confirmed' | 'failed' | 'cancelled' | 'refunded';
+  /** Set when status=cancelled — mirrored from contract withdrawable_ratio_bps. */
+  withdrawableRatioBps?: number | null;
   transactionId: string; // blockchain tx hash — unique identifier
   idempotencyKey?: string; // unique idempotency key for safe retries
   // ── Blockchain-specific fields ──────────────────────────────────────────────
@@ -35,6 +37,7 @@ const transactionSchema = new Schema<ITransaction>(
       enum: ['pending', 'confirmed', 'failed', 'cancelled', 'refunded'],
       default: 'pending',
     },
+    withdrawableRatioBps: { type: Number, default: null },
     transactionId: { type: String, required: true, unique: true },
     idempotencyKey: { type: String, sparse: true, unique: true },
     // Blockchain metadata — populated by the state machine on each transition
@@ -46,7 +49,10 @@ const transactionSchema = new Schema<ITransaction>(
 );
 
 // Compound index for duplicate detection: (user + eventTicket + transactionId)
-transactionSchema.index({ user: 1, eventTicket: 1, transactionId: 1 }, { unique: true });
+transactionSchema.index(
+  { user: 1, eventTicket: 1, transactionId: 1 },
+  { unique: true },
+);
 // Index for reconciliation queries (find stale pending transactions quickly)
 transactionSchema.index({ status: 1, transactionDate: 1 });
 

--- a/src/provider/payments-contract.provider.ts
+++ b/src/provider/payments-contract.provider.ts
@@ -1,0 +1,38 @@
+import { EventFinancialState } from '../types/payments-contract.types';
+
+export interface IPaymentsContractProvider {
+  getEventFinancialState(onChainEventId: string): Promise<EventFinancialState>;
+  getPlatformFeeBps(): Promise<number>;
+}
+
+let providerOverride: IPaymentsContractProvider | null = null;
+
+/** Test hook — inject a mock provider. */
+export function setPaymentsContractProvider(
+  provider: IPaymentsContractProvider | null,
+): void {
+  providerOverride = provider;
+}
+
+export function isPaymentsContractConfigured(): boolean {
+  return Boolean(
+    process.env.SOROBAN_RPC_URL && process.env.PAYMENTS_CONTRACT_ID,
+  );
+}
+
+export function getPaymentsContractProvider(): IPaymentsContractProvider {
+  if (providerOverride) return providerOverride;
+
+  if (!isPaymentsContractConfigured()) {
+    throw new Error(
+      'SOROBAN_RPC_URL and PAYMENTS_CONTRACT_ID must be configured for contract reads',
+    );
+  }
+
+  // Lazy load to avoid pulling @stellar/stellar-sdk into unit tests.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const {
+    SorobanPaymentsContractProvider,
+  } = require('./soroban-payments-contract.provider');
+  return SorobanPaymentsContractProvider.getInstance();
+}

--- a/src/provider/soroban-payments-contract.provider.ts
+++ b/src/provider/soroban-payments-contract.provider.ts
@@ -1,0 +1,117 @@
+import {
+  BASE_FEE,
+  Contract,
+  nativeToScVal,
+  rpc,
+  scValToNative,
+  TransactionBuilder,
+  Account,
+  xdr,
+} from '@stellar/stellar-sdk';
+import { EventFinancialState } from '../types/payments-contract.types';
+import { IPaymentsContractProvider } from './payments-contract.provider';
+
+interface EventConfigOnChain {
+  cancel_ledger?: number | null;
+  withdrawable_ratio_bps?: number | null;
+  organizer_withdrawn?: boolean;
+}
+
+/**
+ * Reads payments contract state via Soroban RPC simulation.
+ * Env: SOROBAN_RPC_URL, PAYMENTS_CONTRACT_ID, SOROBAN_NETWORK_PASSPHRASE
+ */
+export class SorobanPaymentsContractProvider implements IPaymentsContractProvider {
+  private static _instance: SorobanPaymentsContractProvider | null = null;
+  private readonly server: rpc.Server;
+  private readonly contract: Contract;
+  private readonly networkPassphrase: string;
+
+  private constructor() {
+    const rpcUrl = process.env.SOROBAN_RPC_URL || '';
+    const contractId = process.env.PAYMENTS_CONTRACT_ID || '';
+    if (!rpcUrl || !contractId) {
+      throw new Error(
+        'SOROBAN_RPC_URL and PAYMENTS_CONTRACT_ID must be configured for contract reads',
+      );
+    }
+
+    this.networkPassphrase =
+      process.env.SOROBAN_NETWORK_PASSPHRASE ||
+      'Test SDF Network ; September 2015';
+    this.server = new rpc.Server(rpcUrl, {
+      allowHttp: rpcUrl.startsWith('http://'),
+    });
+    this.contract = new Contract(contractId);
+  }
+
+  static getInstance(): SorobanPaymentsContractProvider {
+    if (!this._instance) this._instance = new SorobanPaymentsContractProvider();
+    return this._instance;
+  }
+
+  async getPlatformFeeBps(): Promise<number> {
+    const result = await this.simulateRead('get_platform_fee_bps');
+    return Number(scValToNative(result));
+  }
+
+  async getEventFinancialState(
+    onChainEventId: string,
+  ): Promise<EventFinancialState> {
+    const [configVal, revenueVal, platformFeeBps] = await Promise.all([
+      this.simulateRead('get_event_config', onChainEventId),
+      this.simulateRead('get_event_revenue', onChainEventId),
+      this.getPlatformFeeBps(),
+    ]);
+
+    const config = scValToNative(configVal) as EventConfigOnChain;
+
+    return {
+      onChainEventId,
+      withdrawableRatioBps:
+        config.withdrawable_ratio_bps != null
+          ? config.withdrawable_ratio_bps
+          : null,
+      cancelLedger: config.cancel_ledger ?? null,
+      organizerWithdrawn: Boolean(config.organizer_withdrawn),
+      totalRevenue: BigInt(
+        scValToNative(revenueVal) as string | number | bigint,
+      ),
+      platformFeeBps,
+    };
+  }
+
+  private async simulateRead(
+    method: string,
+    eventId?: string,
+  ): Promise<xdr.ScVal> {
+    const simulationAccount = new Account(
+      'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+      '0',
+    );
+
+    const args = eventId ? [nativeToScVal(eventId, { type: 'symbol' })] : [];
+
+    const tx = new TransactionBuilder(simulationAccount, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(this.contract.call(method, ...args))
+      .setTimeout(180)
+      .build();
+
+    const simulation = await this.server.simulateTransaction(tx);
+
+    if (rpc.Api.isSimulationError(simulation)) {
+      throw new Error(
+        `Soroban simulation failed for ${method}: ${simulation.error}`,
+      );
+    }
+
+    if (!simulation.result?.retval) {
+      throw new Error(`Soroban simulation returned no value for ${method}`);
+    }
+
+    return simulation.result.retval;
+  }
+}

--- a/src/routes/event-ticket.route.ts
+++ b/src/routes/event-ticket.route.ts
@@ -10,6 +10,7 @@ import {
   scanTicket,
   validateTicket,
 } from '../controllers/event-ticket.controller';
+import { getOrganizerBalance } from '../controllers/organizer-balance.controller';
 import { authGuard } from '../middlewares/auth';
 
 const eventTicketRoutes = Router();
@@ -31,6 +32,13 @@ eventTicketRoutes.get('/category/:category', getEventTicketsByCategory);
 
 // GET /api/event-tickets/search - Search event tickets
 eventTicketRoutes.get('/search', searchEventTickets);
+
+// GET /api/event-tickets/:eventId/organizer-balance - Proportional balance from contract
+eventTicketRoutes.get(
+  '/:eventId/organizer-balance',
+  authGuard,
+  getOrganizerBalance,
+);
 
 // GET /api/event-tickets/:eventId - Fetch a single event by ID
 eventTicketRoutes.get('/:eventId', getEventById);

--- a/src/services/organizer-balance.service.ts
+++ b/src/services/organizer-balance.service.ts
@@ -1,0 +1,60 @@
+import {
+  EventFinancialState,
+  OrganizerBalanceSnapshot,
+} from '../types/payments-contract.types';
+import {
+  computeOrganizerPayout,
+  computeRefundPoolAmount,
+  computeWithdrawableAmount,
+} from '../utils/proportional-cancellation';
+import {
+  getPaymentsContractProvider,
+  IPaymentsContractProvider,
+} from '../provider/payments-contract.provider';
+
+export class OrganizerBalanceService {
+  /**
+   * Build a dashboard balance snapshot from contract-sourced financial state.
+   * All proportional amounts derive from withdrawable_ratio_bps returned by the contract.
+   */
+  static computeFromContractState(
+    eventStatus: string,
+    state: EventFinancialState,
+  ): OrganizerBalanceSnapshot {
+    const ratio = state.withdrawableRatioBps ?? 0;
+    const withdrawableAmount = computeWithdrawableAmount(
+      state.totalRevenue,
+      ratio,
+    );
+    const refundPoolAmount = computeRefundPoolAmount(state.totalRevenue, ratio);
+    const organizerPayoutAmount = computeOrganizerPayout(
+      withdrawableAmount,
+      state.platformFeeBps,
+    );
+
+    return {
+      onChainEventId: state.onChainEventId,
+      eventStatus,
+      totalRevenue: state.totalRevenue.toString(),
+      withdrawableRatioBps: state.withdrawableRatioBps,
+      withdrawableAmount: withdrawableAmount.toString(),
+      refundPoolAmount: refundPoolAmount.toString(),
+      organizerPayoutAmount: organizerPayoutAmount.toString(),
+      organizerWithdrawn: state.organizerWithdrawn,
+      platformFeeBps: state.platformFeeBps,
+      source: 'contract',
+    };
+  }
+
+  /**
+   * Reads live contract storage and returns the organizer dashboard balance.
+   */
+  static async getOrganizerBalanceForEvent(
+    onChainEventId: string,
+    eventStatus: string,
+    provider: IPaymentsContractProvider = getPaymentsContractProvider(),
+  ): Promise<OrganizerBalanceSnapshot> {
+    const state = await provider.getEventFinancialState(onChainEventId);
+    return this.computeFromContractState(eventStatus, state);
+  }
+}

--- a/src/services/reconciliation.service.ts
+++ b/src/services/reconciliation.service.ts
@@ -1,5 +1,10 @@
 import Transaction from '../models/transaction';
+import EventTicket from '../models/event-ticket';
 import { BlockchainProvider } from '../provider/blockchain.provider';
+import {
+  getPaymentsContractProvider,
+  isPaymentsContractConfigured,
+} from '../provider/payments-contract.provider';
 import {
   TransactionStateMachine,
   TransactionEvent,
@@ -26,6 +31,8 @@ export interface ReconciliationReport {
   confirmed: number;
   failed: number;
   skipped: number;
+  cancelledEventsSynced: number;
+  cancelledTransactionsUpdated: number;
   errors: string[];
   durationMs: number;
 }
@@ -39,6 +46,8 @@ export class ReconciliationService {
       confirmed: 0,
       failed: 0,
       skipped: 0,
+      cancelledEventsSynced: 0,
+      cancelledTransactionsUpdated: 0,
       errors: [],
       durationMs: 0,
     };
@@ -122,5 +131,104 @@ export class ReconciliationService {
     );
 
     return report;
+  }
+
+  /**
+   * Sync proportional-cancellation financial state from the payments contract.
+   * Reads withdrawable_ratio_bps directly from contract storage (never re-derived).
+   */
+  static async reconcileCancelledEventFinances(
+    report?: ReconciliationReport,
+  ): Promise<ReconciliationReport> {
+    const startTime = Date.now();
+    const localReport: ReconciliationReport = report ?? {
+      scanned: 0,
+      confirmed: 0,
+      failed: 0,
+      skipped: 0,
+      cancelledEventsSynced: 0,
+      cancelledTransactionsUpdated: 0,
+      errors: [],
+      durationMs: 0,
+    };
+
+    if (!isPaymentsContractConfigured()) {
+      console.warn(
+        '[Reconciliation] Skipping cancelled-event sync — Soroban contract not configured',
+      );
+      return localReport;
+    }
+
+    const provider = getPaymentsContractProvider();
+
+    const cancelledEvents = await EventTicket.find({
+      eventStatus: 'cancelled',
+      onChainEventId: { $exists: true, $ne: null },
+    })
+      .lean()
+      .limit(200);
+
+    for (const event of cancelledEvents) {
+      const onChainEventId = event.onChainEventId as string;
+
+      try {
+        const financialState =
+          await provider.getEventFinancialState(onChainEventId);
+
+        if (financialState.withdrawableRatioBps === null) {
+          localReport.skipped++;
+          continue;
+        }
+
+        await EventTicket.findByIdAndUpdate(event._id, {
+          withdrawableRatioBps: financialState.withdrawableRatioBps,
+          cancelLedger: financialState.cancelLedger,
+          organizerWithdrawn: financialState.organizerWithdrawn,
+        });
+
+        localReport.cancelledEventsSynced++;
+
+        const confirmedTxs = await Transaction.find({
+          eventTicket: event._id,
+          status: 'confirmed',
+        }).lean();
+
+        for (const tx of confirmedTxs) {
+          const result = await TransactionStateMachine.apply(
+            'EVENT_CANCELLED',
+            {
+              txHash: tx.transactionId,
+              withdrawableRatioBps: financialState.withdrawableRatioBps,
+              triggeredBy: 'reconciliation',
+            },
+          );
+
+          if (result.transitioned) {
+            localReport.cancelledTransactionsUpdated++;
+          }
+        }
+      } catch (error) {
+        const msg = `Failed to reconcile cancelled event ${onChainEventId}: ${
+          error instanceof Error ? error.message : 'Unknown'
+        }`;
+        localReport.errors.push(msg);
+        console.error(`[Reconciliation] ${msg}`);
+      }
+    }
+
+    localReport.durationMs = Date.now() - startTime;
+    return localReport;
+  }
+
+  /**
+   * Full reconciliation pass: stale pending txs + cancelled-event finances.
+   */
+  static async reconcileAll(): Promise<ReconciliationReport> {
+    const startTime = Date.now();
+    const pendingReport = await this.reconcilePendingTransactions();
+    const fullReport =
+      await this.reconcileCancelledEventFinances(pendingReport);
+    fullReport.durationMs = Date.now() - startTime;
+    return fullReport;
   }
 }

--- a/src/state-machine/transaction.state-machine.ts
+++ b/src/state-machine/transaction.state-machine.ts
@@ -10,7 +10,7 @@ import { TransactionStateError } from '../errors/AppError';
  * Canonical blockchain transaction states.
  * These map 1-to-1 with Transaction.status in the DB.
  */
-export type TransactionState = 'pending' | 'confirmed' | 'failed';
+export type TransactionState = 'pending' | 'confirmed' | 'failed' | 'cancelled';
 
 /**
  * Events that drive state transitions.
@@ -19,12 +19,14 @@ export type TransactionState = 'pending' | 'confirmed' | 'failed';
  *  CHAIN_FAILED     — on-chain receipt shows status=0 (reverted)
  *  CHAIN_DROPPED    — tx not found after stale timeout (treat as failed)
  *  CHAIN_PENDING    — tx found but not yet mined / under-confirmed (no-op)
+ *  EVENT_CANCELLED  — event cancelled on-chain; stores withdrawable_ratio_bps from contract
  */
 export type TransactionEvent =
   | 'CHAIN_CONFIRMED'
   | 'CHAIN_FAILED'
   | 'CHAIN_DROPPED'
-  | 'CHAIN_PENDING';
+  | 'CHAIN_PENDING'
+  | 'EVENT_CANCELLED';
 
 /**
  * Context passed into every transition.
@@ -33,7 +35,9 @@ export interface TransitionContext {
   txHash: string;
   blockNumber?: number;
   confirmations?: number;
-  /** Source that triggered the transition: webhook, reconciliation, or direct verify */
+  /** Contract-sourced ratio (bps). Required for EVENT_CANCELLED. */
+  withdrawableRatioBps?: number;
+  /** Source that triggered the transition */
   triggeredBy: 'webhook' | 'reconciliation' | 'direct';
 }
 
@@ -57,19 +61,22 @@ export interface TransitionResult {
  * this is the core guard against false confirmations and double-processing.
  */
 const ALLOWED_TRANSITIONS: Record<TransactionState, Set<TransactionEvent>> = {
-  pending: new Set(['CHAIN_CONFIRMED', 'CHAIN_FAILED', 'CHAIN_DROPPED', 'CHAIN_PENDING']),
-  confirmed: new Set(), // terminal — no transitions allowed
-  failed: new Set(),    // terminal — no transitions allowed
+  pending: new Set([
+    'CHAIN_CONFIRMED',
+    'CHAIN_FAILED',
+    'CHAIN_DROPPED',
+    'CHAIN_PENDING',
+  ]),
+  confirmed: new Set(['EVENT_CANCELLED']),
+  failed: new Set(),
+  cancelled: new Set(),
 };
 
-/**
- * Map event → resulting state (only for state-changing events).
- */
 const EVENT_TO_STATE: Partial<Record<TransactionEvent, TransactionState>> = {
   CHAIN_CONFIRMED: 'confirmed',
   CHAIN_FAILED: 'failed',
   CHAIN_DROPPED: 'failed',
-  // CHAIN_PENDING is a no-op — state stays 'pending'
+  EVENT_CANCELLED: 'cancelled',
 };
 
 // ─── State Machine ────────────────────────────────────────────────────────────
@@ -93,13 +100,32 @@ export class TransactionStateMachine {
    *  - TicketOrder.status → 3 (failed)
    *  - Inventory released back to pool
    *
+   * Side-effects on EVENT_CANCELLED:
+   *  - Transaction.status → 'cancelled' with withdrawableRatioBps from contract
+   *  - TicketOrder.status → 2 (cancelled) for completed orders
+   *
    * @throws TransactionStateError for illegal transitions
    */
   static async apply(
     event: TransactionEvent,
     ctx: TransitionContext,
   ): Promise<TransitionResult> {
-    const { txHash, blockNumber, confirmations, triggeredBy } = ctx;
+    const {
+      txHash,
+      blockNumber,
+      confirmations,
+      triggeredBy,
+      withdrawableRatioBps,
+    } = ctx;
+
+    if (event === 'EVENT_CANCELLED' && withdrawableRatioBps === undefined) {
+      throw new TransactionStateError(
+        'EVENT_CANCELLED requires withdrawableRatioBps from contract storage',
+        txHash,
+        'unknown' as TransactionState,
+        event,
+      );
+    }
 
     // ── Load transaction ──────────────────────────────────────────────────────
     const tx = await Transaction.findOne({ transactionId: txHash });
@@ -160,22 +186,27 @@ export class TransactionStateMachine {
           status: targetState,
           ...(blockNumber !== undefined && { blockNumber }),
           ...(confirmations !== undefined && { confirmations }),
+          ...(event === 'EVENT_CANCELLED' && {
+            withdrawableRatioBps,
+          }),
           lastCheckedAt: new Date(),
         },
         { session },
       );
 
-      // Find the matching pending TicketOrder
+      const orderStatusFilter = targetState === 'cancelled' ? 1 : 0;
+
       const order = await TicketOrder.findOne({
         user: tx.user,
         eventTicket: tx.eventTicket,
-        status: 0, // pending
+        status: orderStatusFilter,
       })
         .sort({ datePurchased: -1 })
         .session(session);
 
       if (order) {
-        const newOrderStatus = targetState === 'confirmed' ? 1 : 3;
+        const newOrderStatus =
+          targetState === 'confirmed' ? 1 : targetState === 'cancelled' ? 2 : 3;
 
         await TicketOrder.findByIdAndUpdate(
           order._id,
@@ -185,18 +216,19 @@ export class TransactionStateMachine {
 
         if (targetState === 'confirmed') {
           // Confirm inventory deduction (validates consistency)
-          const confirmResult = await InventoryService.confirmInventoryDeduction(
-            tx.eventTicket.toString(),
-            order.quantity,
-            session,
-          );
+          const confirmResult =
+            await InventoryService.confirmInventoryDeduction(
+              tx.eventTicket.toString(),
+              order.quantity,
+              session,
+            );
 
           if (!confirmResult.success) {
             console.warn(
               `[StateMachine] Inventory confirmation issue for order ${order._id}: ${confirmResult.error}`,
             );
           }
-        } else {
+        } else if (targetState === 'failed') {
           // Release inventory back to pool on failure
           const releaseResult = await InventoryService.releaseInventory(
             tx.eventTicket.toString(),
@@ -236,7 +268,10 @@ export class TransactionStateMachine {
   /**
    * Convenience: check whether a transition is valid without executing it.
    */
-  static canApply(currentState: TransactionState, event: TransactionEvent): boolean {
+  static canApply(
+    currentState: TransactionState,
+    event: TransactionEvent,
+  ): boolean {
     return ALLOWED_TRANSITIONS[currentState]?.has(event) ?? false;
   }
 
@@ -277,10 +312,15 @@ export class TransactionStateMachine {
    */
   static toOrderStatus(state: TransactionState): number {
     switch (state) {
-      case 'confirmed': return 1;
-      case 'failed':    return 3;
+      case 'confirmed':
+        return 1;
+      case 'cancelled':
+        return 2;
+      case 'failed':
+        return 3;
       case 'pending':
-      default:          return 0;
+      default:
+        return 0;
     }
   }
 }

--- a/src/types/payments-contract.types.ts
+++ b/src/types/payments-contract.types.ts
@@ -1,0 +1,28 @@
+/**
+ * On-chain financial snapshot read from the Soroban payments contract.
+ * withdrawable_ratio_bps is always sourced from contract storage — never derived off-chain.
+ */
+export interface EventFinancialState {
+  onChainEventId: string;
+  /** Basis points [0, 10000] the organizer may withdraw when cancelled. null if not cancelled on-chain. */
+  withdrawableRatioBps: number | null;
+  cancelLedger: number | null;
+  organizerWithdrawn: boolean;
+  /** Total held revenue (get_event_revenue). */
+  totalRevenue: bigint;
+  platformFeeBps: number;
+}
+
+export interface OrganizerBalanceSnapshot {
+  onChainEventId: string;
+  eventStatus: string;
+  totalRevenue: string;
+  withdrawableRatioBps: number | null;
+  withdrawableAmount: string;
+  refundPoolAmount: string;
+  organizerPayoutAmount: string;
+  organizerWithdrawn: boolean;
+  platformFeeBps: number;
+  /** Indicates values were computed from live contract reads. */
+  source: 'contract';
+}

--- a/src/utils/proportional-cancellation.ts
+++ b/src/utils/proportional-cancellation.ts
@@ -1,0 +1,41 @@
+/**
+ * Financial math mirrored from zicket-contract/contracts/payments/src/lib.rs
+ * (withdraw, claim_refund, cancel_event). Integer division matches Soroban i128/u32.
+ */
+
+export const BPS_DENOMINATOR = 10_000;
+
+/** Organizer withdrawable amount before platform fee (withdraw()). */
+export function computeWithdrawableAmount(
+  totalHeld: bigint,
+  withdrawableRatioBps: number,
+): bigint {
+  return (totalHeld * BigInt(withdrawableRatioBps)) / BigInt(BPS_DENOMINATOR);
+}
+
+/** Attendee max refund for a held payment (claim_refund()). */
+export function computeMaxRefundAmount(
+  paymentAmount: bigint,
+  withdrawableRatioBps: number,
+): bigint {
+  const refundRatioBps = BPS_DENOMINATOR - withdrawableRatioBps;
+  if (refundRatioBps <= 0) return 0n;
+  return (paymentAmount * BigInt(refundRatioBps)) / BigInt(BPS_DENOMINATOR);
+}
+
+/** Organizer net payout after platform fee (withdraw()). */
+export function computeOrganizerPayout(
+  withdrawableAmount: bigint,
+  platformFeeBps: number,
+): bigint {
+  const feeAmount =
+    (withdrawableAmount * BigInt(platformFeeBps)) / BigInt(BPS_DENOMINATOR);
+  return withdrawableAmount - feeAmount;
+}
+
+export function computeRefundPoolAmount(
+  totalHeld: bigint,
+  withdrawableRatioBps: number,
+): bigint {
+  return totalHeld - computeWithdrawableAmount(totalHeld, withdrawableRatioBps);
+}

--- a/src/workers/reconciliation.worker.ts
+++ b/src/workers/reconciliation.worker.ts
@@ -70,8 +70,7 @@ const reconciliationWorker = new Worker(
 
     switch (name as ReconciliationJobType) {
       case ReconciliationJobType.RECONCILE_PENDING: {
-        const report =
-          await ReconciliationService.reconcilePendingTransactions();
+        const report = await ReconciliationService.reconcileAll();
 
         // Surface any errors through BullMQ's job result
         if (report.errors.length > 0) {
@@ -101,6 +100,8 @@ reconciliationWorker.on('completed', (job, result) => {
     console.log(
       `[ReconciliationWorker] ✓ Run complete — scanned: ${r.scanned}, ` +
         `confirmed: ${r.confirmed}, failed: ${r.failed}, ` +
+        `cancelledEvents: ${r.cancelledEventsSynced}, ` +
+        `cancelledTxs: ${r.cancelledTransactionsUpdated}, ` +
         `skipped: ${r.skipped}, duration: ${r.durationMs}ms`,
     );
   }

--- a/tests/fixtures/mid-event-cancellation.fixture.ts
+++ b/tests/fixtures/mid-event-cancellation.fixture.ts
@@ -1,0 +1,27 @@
+/**
+ * Mid-event cancellation fixture aligned with zicket-contract payments tests:
+ * - bind_event: event_start_ledger=0, event_end_ledger=17280
+ * - cancel_event at ledger 1000
+ * - single payment of 100_000_000 stroops
+ *
+ * Contract formula (lib.rs cancel_event):
+ *   ratio = elapsed * 10000 / total = 1000 * 10000 / 17280 = 578 (integer division)
+ */
+export const MID_EVENT_CANCELLATION_FIXTURE = {
+  onChainEventId: 'EVENTCAN',
+  eventStartLedger: 0,
+  eventEndLedger: 17280,
+  cancelLedger: 1000,
+  /** Integer division — matches Soroban u32 cast in cancel_event. */
+  withdrawableRatioBps: Math.floor((1000 * 10_000) / 17280),
+  totalRevenue: 100_000_000n,
+  platformFeeBps: 0,
+  organizerWithdrawn: false,
+} as const;
+
+/** Expected on-chain balances for the fixture above. */
+export const MID_EVENT_EXPECTED_BALANCES = {
+  withdrawableAmount: 5_780_000n,
+  refundPoolAmount: 94_220_000n,
+  organizerPayoutAmount: 5_780_000n,
+} as const;

--- a/tests/proportional-cancellation.integration.test.ts
+++ b/tests/proportional-cancellation.integration.test.ts
@@ -1,0 +1,201 @@
+import {
+  MID_EVENT_CANCELLATION_FIXTURE,
+  MID_EVENT_EXPECTED_BALANCES,
+} from './fixtures/mid-event-cancellation.fixture';
+import { OrganizerBalanceService } from '../src/services/organizer-balance.service';
+import {
+  computeMaxRefundAmount,
+  computeOrganizerPayout,
+  computeRefundPoolAmount,
+  computeWithdrawableAmount,
+} from '../src/utils/proportional-cancellation';
+import { EventFinancialState } from '../src/types/payments-contract.types';
+import { ReconciliationService } from '../src/services/reconciliation.service';
+import { setPaymentsContractProvider } from '../src/provider/payments-contract.provider';
+import { TransactionStateMachine } from '../src/state-machine/transaction.state-machine';
+
+jest.mock('../src/models/event-ticket');
+jest.mock('../src/models/transaction');
+jest.mock('../src/state-machine/transaction.state-machine', () => {
+  const actual = jest.requireActual(
+    '../src/state-machine/transaction.state-machine',
+  );
+  return {
+    ...actual,
+    TransactionStateMachine: {
+      ...actual.TransactionStateMachine,
+      apply: jest.fn(),
+    },
+  };
+});
+
+import EventTicket from '../src/models/event-ticket';
+import Transaction from '../src/models/transaction';
+
+describe('Proportional cancellation (Issue #3)', () => {
+  const fixture = MID_EVENT_CANCELLATION_FIXTURE;
+
+  const contractState: EventFinancialState = {
+    onChainEventId: fixture.onChainEventId,
+    withdrawableRatioBps: fixture.withdrawableRatioBps,
+    cancelLedger: fixture.cancelLedger,
+    organizerWithdrawn: fixture.organizerWithdrawn,
+    totalRevenue: fixture.totalRevenue,
+    platformFeeBps: fixture.platformFeeBps,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    setPaymentsContractProvider(null);
+  });
+
+  describe('contract-aligned financial math', () => {
+    it('withdrawable_ratio_bps matches contract integer division for mid-event cancel', () => {
+      expect(fixture.withdrawableRatioBps).toBe(578);
+    });
+
+    it('withdrawable and refund pool sum to total held revenue exactly', () => {
+      const withdrawable = computeWithdrawableAmount(
+        fixture.totalRevenue,
+        fixture.withdrawableRatioBps,
+      );
+      const refundPool = computeRefundPoolAmount(
+        fixture.totalRevenue,
+        fixture.withdrawableRatioBps,
+      );
+
+      expect(withdrawable).toBe(MID_EVENT_EXPECTED_BALANCES.withdrawableAmount);
+      expect(refundPool).toBe(MID_EVENT_EXPECTED_BALANCES.refundPoolAmount);
+      expect(withdrawable + refundPool).toBe(fixture.totalRevenue);
+    });
+
+    it('attendee max refund uses complement ratio (claim_refund)', () => {
+      const paymentAmount = 100_000_000n;
+      const maxRefund = computeMaxRefundAmount(
+        paymentAmount,
+        fixture.withdrawableRatioBps,
+      );
+      expect(maxRefund).toBe(MID_EVENT_EXPECTED_BALANCES.refundPoolAmount);
+    });
+
+    it('organizer payout matches on-chain withdraw() with zero platform fee', () => {
+      const withdrawable = computeWithdrawableAmount(
+        fixture.totalRevenue,
+        fixture.withdrawableRatioBps,
+      );
+      const payout = computeOrganizerPayout(
+        withdrawable,
+        fixture.platformFeeBps,
+      );
+      expect(payout).toBe(MID_EVENT_EXPECTED_BALANCES.organizerPayoutAmount);
+    });
+  });
+
+  describe('organizer dashboard balance', () => {
+    it('displayed balances match on-chain values exactly for mid-event cancellation', async () => {
+      const mockProvider = {
+        getEventFinancialState: jest.fn().mockResolvedValue(contractState),
+        getPlatformFeeBps: jest.fn().mockResolvedValue(0),
+      };
+      setPaymentsContractProvider(mockProvider);
+
+      const snapshot =
+        await OrganizerBalanceService.getOrganizerBalanceForEvent(
+          fixture.onChainEventId,
+          'cancelled',
+          mockProvider,
+        );
+
+      expect(snapshot.source).toBe('contract');
+      expect(snapshot.withdrawableRatioBps).toBe(578);
+      expect(snapshot.withdrawableAmount).toBe(
+        MID_EVENT_EXPECTED_BALANCES.withdrawableAmount.toString(),
+      );
+      expect(snapshot.refundPoolAmount).toBe(
+        MID_EVENT_EXPECTED_BALANCES.refundPoolAmount.toString(),
+      );
+      expect(snapshot.organizerPayoutAmount).toBe(
+        MID_EVENT_EXPECTED_BALANCES.organizerPayoutAmount.toString(),
+      );
+      expect(snapshot.totalRevenue).toBe(fixture.totalRevenue.toString());
+
+      // Dashboard must not show binary refunded/not-refunded — ratio is explicit
+      expect(snapshot.withdrawableRatioBps).not.toBe(0);
+      expect(snapshot.withdrawableRatioBps).not.toBe(10_000);
+    });
+  });
+
+  describe('reconciliation reads ratio from contract storage', () => {
+    it('syncs withdrawable_ratio_bps from contract without re-deriving', async () => {
+      const eventId = '507f1f77bcf86cd799439011';
+      const mockProvider = {
+        getEventFinancialState: jest.fn().mockResolvedValue(contractState),
+        getPlatformFeeBps: jest.fn().mockResolvedValue(0),
+      };
+      setPaymentsContractProvider(mockProvider);
+
+      process.env.SOROBAN_RPC_URL = 'http://localhost:8000/soroban/rpc';
+      process.env.PAYMENTS_CONTRACT_ID =
+        'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
+
+      const mockFindByIdAndUpdate = jest.fn().mockResolvedValue({});
+      (EventTicket.find as jest.Mock) = jest.fn().mockReturnValue({
+        lean: jest.fn().mockReturnValue({
+          limit: jest.fn().mockResolvedValue([
+            {
+              _id: eventId,
+              onChainEventId: fixture.onChainEventId,
+              eventStatus: 'cancelled',
+            },
+          ]),
+        }),
+      });
+      (EventTicket.findByIdAndUpdate as jest.Mock) = mockFindByIdAndUpdate;
+
+      (Transaction.find as jest.Mock) = jest.fn().mockReturnValue({
+        lean: jest
+          .fn()
+          .mockResolvedValue([{ transactionId: '0xabc', status: 'confirmed' }]),
+      });
+
+      (TransactionStateMachine.apply as jest.Mock) = jest
+        .fn()
+        .mockResolvedValue({
+          transitioned: true,
+          previousState: 'confirmed',
+          newState: 'cancelled',
+          message: 'ok',
+        });
+
+      const report =
+        await ReconciliationService.reconcileCancelledEventFinances();
+
+      expect(mockProvider.getEventFinancialState).toHaveBeenCalledWith(
+        fixture.onChainEventId,
+      );
+      expect(mockFindByIdAndUpdate).toHaveBeenCalledWith(
+        eventId,
+        expect.objectContaining({
+          withdrawableRatioBps: 578,
+          cancelLedger: fixture.cancelLedger,
+        }),
+      );
+      expect(TransactionStateMachine.apply).toHaveBeenCalledWith(
+        'EVENT_CANCELLED',
+        expect.objectContaining({
+          txHash: '0xabc',
+          withdrawableRatioBps: 578,
+          triggeredBy: 'reconciliation',
+        }),
+      );
+      expect(report.cancelledEventsSynced).toBe(1);
+      expect(report.cancelledTransactionsUpdated).toBe(1);
+
+      delete process.env.SOROBAN_RPC_URL;
+      delete process.env.PAYMENTS_CONTRACT_ID;
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extend the transaction state machine with a `cancelled` state and `EVENT_CANCELLED`, storing `withdrawable_ratio_bps` from contract storage.
- Reconciliation now syncs cancelled-event finances from the Soroban payments contract instead of using a binary refunded/not-refunded model.
- Add `GET /event-tickets/:eventId/organizer-balance` so organizer dashboard balances reflect proportional withdrawable/refund amounts.
- Add integration tests with a mid-event cancellation fixture (578 bps, revenue 100M stroops) matching on-chain math exactly.

Closes #123 for GrantFox

## Test plan
- [x] `npm run build`
- [x] `npm test` (142 tests, including 6 new proportional-cancellation tests)
- [ ] Configure `SOROBAN_RPC_URL` + `PAYMENTS_CONTRACT_ID` and verify organizer balance against a cancelled testnet event
- [ ] Link events with `onChainEventId` before running reconciliation sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an organizer balance view for event tickets, showing live contract-based balance details.
  * Added support for cancelled-event reconciliation, including updated run metrics.

* **Bug Fixes**
  * Improved handling of cancelled events and transactions so balances and refunds reflect contract state more accurately.
  * Updated transaction status handling to include cancelled outcomes.

* **Chores**
  * Added required configuration entries and a new contract SDK dependency for payments-related features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->