### PR TITLE
feat: reconcile data retention with on-chain immutability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,8 @@ REDIS_PASSWORD=
 # ── Reconciliation ────────────────────────────────────────────────────────────
 RECONCILIATION_STALE_MINUTES=30
 RECONCILIATION_CRON=*/15 * * * *
+# ── Data retention / anonymization (#127) ─────────────────────────────────────
+RETENTION_CRON=0 3 * * *
 # ── Soroban / Payments contract (proportional cancellation reads) ─────────────
 SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
 PAYMENTS_CONTRACT_ID=C...

--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,8 @@ CLOUDINARY_API_SECRET=your_api_secret
 BLOCKCHAIN_RPC_URL=https://eth-mainnet.g.alchemy.com/v2/your_key
 PLATFORM_WALLET_ADDRESS=0xYourPlatformWalletAddress
 MIN_CONFIRMATIONS=2
+# ── Data retention / anonymization (#127) ─────────────────────────────────────
+RETENTION_CRON="0 3 * * *"
 WEBHOOK_SECRET=your_hmac_webhook_secret
 # ── Queue / Redis ─────────────────────────────────────────────────────────────
 REDIS_HOST=localhost
@@ -27,8 +29,6 @@ REDIS_PASSWORD=
 # ── Reconciliation ────────────────────────────────────────────────────────────
 RECONCILIATION_STALE_MINUTES=30
 RECONCILIATION_CRON=*/15 * * * *
-# ── Data retention / anonymization (#127) ─────────────────────────────────────
-RETENTION_CRON="0 3 * * *"
 # ── Soroban / Payments contract (proportional cancellation reads) ─────────────
 SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
 PAYMENTS_CONTRACT_ID=C...

--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,7 @@ REDIS_PASSWORD=
 RECONCILIATION_STALE_MINUTES=30
 RECONCILIATION_CRON=*/15 * * * *
 # ── Data retention / anonymization (#127) ─────────────────────────────────────
-RETENTION_CRON=0 3 * * *
+RETENTION_CRON="0 3 * * *"
 # ── Soroban / Payments contract (proportional cancellation reads) ─────────────
 SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
 PAYMENTS_CONTRACT_ID=C...

--- a/docs/compliance/data-retention.md
+++ b/docs/compliance/data-retention.md
@@ -1,6 +1,6 @@
 # Data Retention & On-Chain Immutability (Issue #127)
 
-This document is the internal compliance reference for Zicket backend operators and legal review. The public API mirror lives at `GET /compliance/data-retention`.
+This document is the internal compliance reference for Zicket backend operators and legal review. The public API mirror lives at `GET /compliance/data-retention`. The user-facing summary is at `GET /compliance/privacy-policy`.
 
 ## Core principle
 
@@ -8,39 +8,39 @@ This document is the internal compliance reference for Zicket backend operators 
 
 ## Erasable off-chain data
 
-| Data                                    | Storage                    | Retention             | Erasure                                               |
-| --------------------------------------- | -------------------------- | --------------------- | ----------------------------------------------------- |
-| User profile (name, email, credentials) | MongoDB `User`             | Until erasure         | `POST /account/request-erasure` anonymizes the record |
-| Ticket orders                           | MongoDB `TicketOrder`      | Financial retention   | User link anonymized; order amounts retained          |
-| Transactions                            | MongoDB `Transaction`      | Financial retention   | User link anonymized; tx hash retained                |
-| OTP / magic-link tokens                 | MongoDB `User`             | Until used or erasure | Cleared on anonymization                              |
-| Temporary key-value data                | MongoDB `TempData`         | 7 days (TTL index)    | Auto-expires                                          |
-| Persisted app logs                      | MongoDB `Log`              | 30 days (TTL index)   | Auto-expires                                          |
-| Anonymization audit jobs                | MongoDB `AnonymizationJob` | 90 days (TTL index)   | Contains user id only                                 |
+| Data                                    | Storage                    | Retention           | Erasure                                               |
+| --------------------------------------- | -------------------------- | ------------------- | ----------------------------------------------------- |
+| User profile (name, email, credentials) | MongoDB `User`             | Until erasure       | `POST /account/request-erasure` anonymizes the record |
+| Ticket orders                           | MongoDB `TicketOrder`      | Financial retention | User link anonymized; order amounts retained          |
+| Transactions                            | MongoDB `Transaction`      | Financial retention | User link anonymized; tx hash retained                |
+| OTP / session payloads                  | MongoDB `TempData`         | 7 days (TTL index)  | Auto-expires; not stored on `User` long-term          |
+| Persisted app logs                      | MongoDB `Log`              | 30 days (TTL index) | Auto-expires                                          |
+| Anonymization audit jobs                | MongoDB `AnonymizationJob` | 90 days (TTL index) | Contains user id only                                 |
+| Privacy-stripped indexer events         | MongoDB `ContractEvent`    | Indefinite          | No attendee identity stored                           |
 
 ## Permanent on-chain data
 
-| Data                                                         | Storage         | Erasable?                              |
-| ------------------------------------------------------------ | --------------- | -------------------------------------- |
-| `PaymentRecord` payer wallet (Standard / `paymentPrivacy=1`) | Soroban         | **No** — disclosed before payment      |
-| `PaymentRecord` for Anonymous (`paymentPrivacy=0`)           | Soroban         | N/A — no payer wallet stored in record |
-| Event revenue / cancellation ratios                          | Soroban         | **No**                                 |
-| Privacy-stripped contract events (`ContractEvent`)           | MongoDB indexer | No attendee identity stored            |
+| Data                                                         | Storage | Erasable?                                         |
+| ------------------------------------------------------------ | ------- | ------------------------------------------------- |
+| `PaymentRecord` payer wallet (Standard / `paymentPrivacy=1`) | Soroban | **No** — disclosed before payment                 |
+| `PaymentRecord` (Anonymous / `paymentPrivacy=0`)             | Soroban | **No** — permanent record; wallet address omitted |
+| Event revenue / cancellation ratios                          | Soroban | **No**                                            |
 
 ## Payment privacy levels
 
-| `paymentPrivacy` | Label             | On-chain wallet in PaymentRecord | Pre-payment acknowledgment                 |
-| ---------------- | ----------------- | -------------------------------- | ------------------------------------------ |
-| `0`              | Anonymous         | No                               | Notice only                                |
-| `1`              | Standard (public) | Yes                              | **Required** (`privacyAcknowledged: true`) |
+| `paymentPrivacy` | Label             | On-chain wallet in PaymentRecord | PaymentRecord permanent | Pre-payment acknowledgment                 |
+| ---------------- | ----------------- | -------------------------------- | ----------------------- | ------------------------------------------ |
+| `0`              | Anonymous         | No                               | Yes                     | Notice only                                |
+| `1`              | Standard (public) | Yes                              | Yes                     | **Required** (`privacyAcknowledged: true`) |
 
 Free events (`eventType=0`) do not trigger payment privacy disclosures.
 
 ## User-facing disclosure flow
 
-1. `GET /event-tickets/:eventId` returns `paymentDisclosure` for paid events.
-2. `GET /compliance/payment-privacy-disclosure/:eventId` provides the same disclosure standalone.
-3. `POST /ticket-orders/verify-payment` requires `privacyAcknowledged: true` when `paymentPrivacy=1`.
+1. `GET /compliance/privacy-policy` — user-facing erasable vs permanent summary.
+2. `GET /event-tickets/:eventId` returns `paymentDisclosure` for paid events.
+3. `GET /compliance/payment-privacy-disclosure/:eventId` provides the same disclosure standalone.
+4. `POST /ticket-orders/verify-payment` requires `privacyAcknowledged: true` when `paymentPrivacy=1`.
 
 ## Right-to-erasure workflow
 
@@ -48,12 +48,13 @@ Free events (`eventType=0`) do not trigger payment privacy disclosures.
 2. User calls `POST /account/request-erasure` to anonymize off-chain profile data.
 3. Response explicitly states if on-chain Standard payment records remain permanent.
 
-## Verification guarantee (Anonymous-only users)
+## Verification guarantee (Anonymous-only paid history)
 
-Users who **only** purchased paid tickets on events with `paymentPrivacy=0` are assessed as having **no on-chain wallet data** subject to erasure (`anonymousOnlyPaymentHistory: true`, `onChainPermanentData: false`). Users with any Standard (`paymentPrivacy=1`) purchase are flagged with `onChainPermanentData: true`.
+Users who **only** purchased paid tickets on events with `paymentPrivacy=0` are assessed as having **no on-chain wallet data** subject to erasure (`anonymousOnlyPaymentHistory: true`, `onChainPermanentData: false`). A permanent anonymous `PaymentRecord` still exists on Soroban without the payer wallet. Users with any Standard (`paymentPrivacy=1`) purchase are flagged with `onChainPermanentData: true`.
 
 ## API reference
 
+- `GET /compliance/privacy-policy` — user-facing privacy summary
 - `GET /compliance/data-retention` — machine-readable matrix
 - `GET /compliance/payment-privacy-disclosure/:eventId` — pre-payment warning
 - `GET /account/erasure-assessment` — authenticated impact assessment

--- a/docs/compliance/data-retention.md
+++ b/docs/compliance/data-retention.md
@@ -1,0 +1,65 @@
+# Data Retention & On-Chain Immutability (Issue #127)
+
+This document is the internal compliance reference for Zicket backend operators and legal review. The public API mirror lives at `GET /compliance/data-retention`.
+
+## Core principle
+
+**Off-chain data** (MongoDB, Redis) can be erased or anonymized on user request. **On-chain data** (Soroban `PaymentRecord`, event financial state) is **immutable** and cannot be deleted after a transaction is submitted.
+
+## Erasable off-chain data
+
+| Data                                    | Storage                    | Retention             | Erasure                                               |
+| --------------------------------------- | -------------------------- | --------------------- | ----------------------------------------------------- |
+| User profile (name, email, credentials) | MongoDB `User`             | Until erasure         | `POST /account/request-erasure` anonymizes the record |
+| Ticket orders                           | MongoDB `TicketOrder`      | Financial retention   | User link anonymized; order amounts retained          |
+| Transactions                            | MongoDB `Transaction`      | Financial retention   | User link anonymized; tx hash retained                |
+| OTP / magic-link tokens                 | MongoDB `User`             | Until used or erasure | Cleared on anonymization                              |
+| Temporary key-value data                | MongoDB `TempData`         | 7 days (TTL index)    | Auto-expires                                          |
+| Persisted app logs                      | MongoDB `Log`              | 30 days (TTL index)   | Auto-expires                                          |
+| Anonymization audit jobs                | MongoDB `AnonymizationJob` | 90 days (TTL index)   | Contains user id only                                 |
+
+## Permanent on-chain data
+
+| Data                                                         | Storage         | Erasable?                              |
+| ------------------------------------------------------------ | --------------- | -------------------------------------- |
+| `PaymentRecord` payer wallet (Standard / `paymentPrivacy=1`) | Soroban         | **No** — disclosed before payment      |
+| `PaymentRecord` for Anonymous (`paymentPrivacy=0`)           | Soroban         | N/A — no payer wallet stored in record |
+| Event revenue / cancellation ratios                          | Soroban         | **No**                                 |
+| Privacy-stripped contract events (`ContractEvent`)           | MongoDB indexer | No attendee identity stored            |
+
+## Payment privacy levels
+
+| `paymentPrivacy` | Label             | On-chain wallet in PaymentRecord | Pre-payment acknowledgment                 |
+| ---------------- | ----------------- | -------------------------------- | ------------------------------------------ |
+| `0`              | Anonymous         | No                               | Notice only                                |
+| `1`              | Standard (public) | Yes                              | **Required** (`privacyAcknowledged: true`) |
+
+Free events (`eventType=0`) do not trigger payment privacy disclosures.
+
+## User-facing disclosure flow
+
+1. `GET /event-tickets/:eventId` returns `paymentDisclosure` for paid events.
+2. `GET /compliance/payment-privacy-disclosure/:eventId` provides the same disclosure standalone.
+3. `POST /ticket-orders/verify-payment` requires `privacyAcknowledged: true` when `paymentPrivacy=1`.
+
+## Right-to-erasure workflow
+
+1. User calls `GET /account/erasure-assessment` to learn off-chain vs on-chain impact.
+2. User calls `POST /account/request-erasure` to anonymize off-chain profile data.
+3. Response explicitly states if on-chain Standard payment records remain permanent.
+
+## Verification guarantee (Anonymous-only users)
+
+Users who **only** purchased paid tickets on events with `paymentPrivacy=0` are assessed as having **no on-chain wallet data** subject to erasure (`anonymousOnlyPaymentHistory: true`, `onChainPermanentData: false`). Users with any Standard (`paymentPrivacy=1`) purchase are flagged with `onChainPermanentData: true`.
+
+## API reference
+
+- `GET /compliance/data-retention` — machine-readable matrix
+- `GET /compliance/payment-privacy-disclosure/:eventId` — pre-payment warning
+- `GET /account/erasure-assessment` — authenticated impact assessment
+- `POST /account/request-erasure` — authenticated off-chain anonymization
+
+## Related issues
+
+- GitHub [#127](https://github.com/BuidlZone-Labs/zicket-backend/issues/127)
+- Original retention layer [#87](https://github.com/BuidlZone-Labs/zicket-backend/issues/87)

--- a/docs/compliance/privacy-policy.md
+++ b/docs/compliance/privacy-policy.md
@@ -1,0 +1,29 @@
+# Zicket Privacy Policy — Data Retention Summary
+
+This is the user-facing privacy summary referenced by issue #127. The live API version is at `GET /compliance/privacy-policy`.
+
+## What we can delete (off-chain)
+
+When you request erasure, we anonymize profile data stored in our database: your name, email, authentication tokens, and notification preferences. Ticket and payment records in our database keep financial amounts for audit, but your personal linkage is removed.
+
+Temporary data (sessions, OTP payloads in `TempData`) expires automatically within 7 days.
+
+## What we cannot delete (on-chain)
+
+Payments on the Stellar/Soroban blockchain create **permanent** records:
+
+- **Standard (public) payments** store your paying wallet address on-chain. This cannot be erased, including under GDPR right-to-erasure requests.
+- **Anonymous payments** still create a permanent `PaymentRecord`, but your wallet address is **not** stored in that record.
+
+Event financial state (revenue, cancellation ratios) on Soroban is also immutable.
+
+## Before you pay
+
+If an event uses Standard payment privacy, you must acknowledge (`privacyAcknowledged: true`) that your wallet will be stored permanently on-chain before we process your payment.
+
+## How to exercise your rights
+
+1. `GET /account/erasure-assessment` — see what can and cannot be erased for your account.
+2. `POST /account/request-erasure` — anonymize off-chain profile data.
+
+Full technical matrix: `GET /compliance/data-retention`

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,8 @@ import ticketOrderRoutes from './routes/ticket-order.route';
 import queueMonitorRoutes from './routes/queue-monitor.route';
 import zkEmailRoutes from './routes/zkemail.route';
 import indexerRoutes from './routes/indexer.route';
+import privacyComplianceRoutes from './routes/privacy-compliance.route';
+import accountRoutes from './routes/account.route';
 import { globalErrorHandler } from './middlewares/errorHandler';
 
 const app = express();
@@ -49,6 +51,8 @@ app.use('/ticket-orders', ticketOrderRoutes);
 app.use('/api', queueMonitorRoutes);
 app.use('/zkemail', authLimiter, zkEmailRoutes);
 app.use('/api/events', indexerRoutes);
+app.use('/compliance', privacyComplianceRoutes);
+app.use('/account', accountRoutes);
 app.use(protectedRoute);
 
 app.use(globalErrorHandler);

--- a/src/config/queue-jobs.ts
+++ b/src/config/queue-jobs.ts
@@ -144,6 +144,20 @@ export interface ReconcilePayload {
 export type ReconciliationJobPayload = ReconcilePayload;
 
 /**
+ * #127 — Data retention / anonymization queue job types
+ */
+export enum RetentionJobType {
+  RUN_RETENTION_PASS = 'RUN_RETENTION_PASS',
+}
+
+export interface RetentionPayload {
+  triggeredBy: 'schedule' | 'manual';
+  timestamp: number;
+}
+
+export type RetentionJobPayload = RetentionPayload;
+
+/**
  * Queue names — centralised so nothing is hard-coded elsewhere
  */
 export const QUEUE_NAMES = {
@@ -151,6 +165,7 @@ export const QUEUE_NAMES = {
   ZKEMAIL: 'zkemail-queue',
   PAYMENT: 'payment-queue', // #81
   RECONCILIATION: 'reconciliation-queue', // #78
+  RETENTION: 'retention-queue', // #127
   ANALYTICS: 'analytics-queue',
 } as const;
 
@@ -167,6 +182,16 @@ export const REPEATABLE_JOBS = {
       },
       attempts: 2,
       backoff: { type: 'fixed' as const, delay: 30_000 },
+    },
+  },
+  RUN_RETENTION_PASS: {
+    name: RetentionJobType.RUN_RETENTION_PASS,
+    opts: {
+      repeat: {
+        pattern: process.env.RETENTION_CRON || '0 3 * * *',
+      },
+      attempts: 2,
+      backoff: { type: 'fixed' as const, delay: 60_000 },
     },
   },
 } as const;

--- a/src/constants/data-retention-matrix.ts
+++ b/src/constants/data-retention-matrix.ts
@@ -91,8 +91,28 @@ export const PRIVACY_POLICY_SUMMARY = {
   onChainPermanent:
     'Soroban payment and event records are immutable. Standard (public) payments may store your wallet address on-chain permanently; it cannot be deleted after submission.',
   anonymousPaymentGuarantee:
-    'Events configured with paymentPrivacy=0 (Anonymous) do not store your wallet address in PaymentRecord on-chain.',
+    'Events configured with paymentPrivacy=0 (Anonymous) create a permanent Soroban PaymentRecord but do not store your wallet address in that record.',
   standardPaymentWarning:
     'Events configured with paymentPrivacy=1 (Standard/Public) store your paying wallet address on the blockchain. This cannot be erased under any right-to-erasure request.',
-  policyDocumentPath: 'docs/compliance/data-retention.md',
+  policyDocumentPath: '/compliance/data-retention',
+  userFacingPrivacyPolicyPath: '/compliance/privacy-policy',
+};
+
+/** User-facing privacy policy sections served at GET /compliance/privacy-policy. */
+export const USER_FACING_PRIVACY_POLICY = {
+  title: 'Zicket Privacy & Data Retention Summary',
+  sections: [
+    {
+      heading: 'Data we can erase (off-chain)',
+      body: 'Your profile, email, authentication tokens, and preferences stored in our database can be anonymized when you submit a right-to-erasure request via POST /account/request-erasure.',
+    },
+    {
+      heading: 'Data we cannot erase (on-chain)',
+      body: 'Blockchain payment records on Stellar/Soroban are permanent. Standard (public) payments store your wallet address on-chain and cannot be deleted. Anonymous payments still create a permanent PaymentRecord but omit your wallet address.',
+    },
+    {
+      heading: 'Before you pay',
+      body: 'Paid events with Standard payment privacy require you to acknowledge that your wallet will be stored permanently on-chain before payment is processed.',
+    },
+  ],
 };

--- a/src/constants/data-retention-matrix.ts
+++ b/src/constants/data-retention-matrix.ts
@@ -1,0 +1,98 @@
+/**
+ * Canonical on-chain vs off-chain data retention matrix (Issue #127).
+ * Served via GET /compliance/data-retention and documented in docs/compliance/data-retention.md.
+ */
+
+export interface DataRetentionRow {
+  data: string;
+  storedWhere: 'mongodb' | 'soroban' | 'redis' | 'not_stored' | 'relay_only';
+  retention: string;
+  erasableOnRequest: 'yes' | 'no' | 'n_a' | 'partial';
+  notes: string;
+}
+
+export const DATA_RETENTION_MATRIX: DataRetentionRow[] = [
+  {
+    data: 'User profile (name, email, password hash)',
+    storedWhere: 'mongodb',
+    retention: 'Until account erasure or anonymization',
+    erasableOnRequest: 'yes',
+    notes: 'Removed or anonymized by POST /account/request-erasure',
+  },
+  {
+    data: 'Ticket orders and transaction records (amounts, tx hash)',
+    storedWhere: 'mongodb',
+    retention: 'Financial record retention policy',
+    erasableOnRequest: 'partial',
+    notes:
+      'User linkage anonymized on erasure; amounts/hashes retained for audit',
+  },
+  {
+    data: 'Temporary session / OTP data',
+    storedWhere: 'mongodb',
+    retention: '7 days (TempData TTL) / until used',
+    erasableOnRequest: 'yes',
+    notes: 'MongoDB TTL on TempData collection',
+  },
+  {
+    data: 'Application logs (if persisted to Log collection)',
+    storedWhere: 'mongodb',
+    retention: '30 days (Log TTL)',
+    erasableOnRequest: 'yes',
+    notes: 'Runtime logs mask emails and wallet addresses',
+  },
+  {
+    data: 'Anonymization job audit trail',
+    storedWhere: 'mongodb',
+    retention: '90 days (AnonymizationJob TTL)',
+    erasableOnRequest: 'n_a',
+    notes: 'Stores target user id only, no PII',
+  },
+  {
+    data: 'zkPassport / zkEmail raw proofs',
+    storedWhere: 'not_stored',
+    retention: 'Never persisted',
+    erasableOnRequest: 'n_a',
+    notes: 'Verified in memory; only commitments may be stored on User',
+  },
+  {
+    data: 'ContractEvent indexer records',
+    storedWhere: 'mongodb',
+    retention: 'Indefinite (no attendee identity)',
+    erasableOnRequest: 'n_a',
+    notes: 'Privacy-stripped on-chain events; no payer/attendee fields',
+  },
+  {
+    data: 'PaymentRecord payer wallet (Standard / paymentPrivacy=1)',
+    storedWhere: 'soroban',
+    retention: 'Permanent (blockchain immutability)',
+    erasableOnRequest: 'no',
+    notes: 'Requires pre-payment disclosure and privacyAcknowledged',
+  },
+  {
+    data: 'PaymentRecord for Anonymous payment (paymentPrivacy=0)',
+    storedWhere: 'soroban',
+    retention: 'Permanent record without payer wallet linkage',
+    erasableOnRequest: 'n_a',
+    notes: 'No wallet address stored on-chain for anonymous payment level',
+  },
+  {
+    data: 'Inventory locks',
+    storedWhere: 'redis',
+    retention: 'Seconds to minutes (lock TTL)',
+    erasableOnRequest: 'yes',
+    notes: 'Ephemeral; no PII',
+  },
+];
+
+export const PRIVACY_POLICY_SUMMARY = {
+  offChainErasable:
+    'Profile data, authentication tokens, and non-financial preferences stored in MongoDB can be erased or anonymized on request.',
+  onChainPermanent:
+    'Soroban payment and event records are immutable. Standard (public) payments may store your wallet address on-chain permanently; it cannot be deleted after submission.',
+  anonymousPaymentGuarantee:
+    'Events configured with paymentPrivacy=0 (Anonymous) do not store your wallet address in PaymentRecord on-chain.',
+  standardPaymentWarning:
+    'Events configured with paymentPrivacy=1 (Standard/Public) store your paying wallet address on the blockchain. This cannot be erased under any right-to-erasure request.',
+  policyDocumentPath: 'docs/compliance/data-retention.md',
+};

--- a/src/controllers/account.controller.ts
+++ b/src/controllers/account.controller.ts
@@ -1,0 +1,86 @@
+import { RequestHandler } from 'express';
+import { UserAuthenticatedReq } from '../utils/types';
+import { ErasureAssessmentService } from '../services/erasure-assessment.service';
+import { AnonymizationService } from '../services/anonymization.service';
+
+/**
+ * GET /account/erasure-assessment
+ * Returns off-chain erasability and any permanent on-chain payment exposure.
+ */
+export const getErasureAssessment: RequestHandler = async (
+  req: UserAuthenticatedReq,
+  res,
+) => {
+  try {
+    const userId = req.user?._id || (req.user as { id?: string })?.id;
+
+    if (!userId) {
+      return res.status(401).json({
+        error: 'Unauthorized',
+        message: 'User authentication required',
+      });
+    }
+
+    const assessment = await ErasureAssessmentService.assessUser(
+      userId.toString(),
+    );
+
+    res.status(200).json({
+      success: true,
+      data: assessment,
+    });
+  } catch (error) {
+    console.error('[Account] getErasureAssessment:', error);
+    res.status(500).json({
+      error: 'Internal server error',
+      message: 'Failed to assess erasure impact',
+    });
+  }
+};
+
+/**
+ * POST /account/request-erasure
+ * Anonymizes off-chain profile data. On-chain Soroban records are unchanged.
+ */
+export const requestErasure: RequestHandler = async (
+  req: UserAuthenticatedReq,
+  res,
+) => {
+  try {
+    const userId = req.user?._id || (req.user as { id?: string })?.id;
+
+    if (!userId) {
+      return res.status(401).json({
+        error: 'Unauthorized',
+        message: 'User authentication required',
+      });
+    }
+
+    const result = await AnonymizationService.requestErasure(userId.toString());
+
+    res.status(200).json({
+      success: true,
+      data: result,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Erasure request failed';
+
+    if (
+      message === 'User not found' ||
+      message === 'Account has already been anonymized'
+    ) {
+      return res.status(404).json({ error: 'Not found', message });
+    }
+
+    if (message === 'An erasure request is already in progress') {
+      return res.status(409).json({ error: 'Conflict', message });
+    }
+
+    console.error('[Account] requestErasure:', error);
+    res.status(500).json({
+      error: 'Internal server error',
+      message: 'Failed to process erasure request',
+    });
+  }
+};

--- a/src/controllers/event-ticket.controller.ts
+++ b/src/controllers/event-ticket.controller.ts
@@ -5,6 +5,7 @@ import {
   CreateEventStepTwoInput,
 } from '../validators/event.validator';
 import { UserAuthenticatedReq } from '../utils/types';
+import { PaymentPrivacyDisclosureService } from '../services/payment-privacy-disclosure.service';
 
 export const getEventTickets: RequestHandler = async (req, res) => {
   try {
@@ -366,6 +367,10 @@ export const getEventById: RequestHandler = async (req, res) => {
         isTrending: event.isTrending,
         eventType: event.eventType,
         paymentPrivacy: event.paymentPrivacy,
+        paymentDisclosure: PaymentPrivacyDisclosureService.buildDisclosure(
+          event.eventType,
+          event.paymentPrivacy,
+        ),
         offerReceipts: event.offerReceipts,
         hasZkEmailUpdates: event.hasZkEmailUpdates,
         hasEventReminders: event.hasEventReminders,

--- a/src/controllers/privacy-compliance.controller.ts
+++ b/src/controllers/privacy-compliance.controller.ts
@@ -1,0 +1,72 @@
+import { RequestHandler } from 'express';
+import mongoose from 'mongoose';
+import EventTicket from '../models/event-ticket';
+import {
+  DATA_RETENTION_MATRIX,
+  PRIVACY_POLICY_SUMMARY,
+} from '../constants/data-retention-matrix';
+import { PaymentPrivacyDisclosureService } from '../services/payment-privacy-disclosure.service';
+
+/**
+ * GET /compliance/data-retention
+ * Public matrix of erasable off-chain vs permanent on-chain data.
+ */
+export const getDataRetentionMatrix: RequestHandler = async (_req, res) => {
+  res.status(200).json({
+    success: true,
+    data: {
+      matrix: DATA_RETENTION_MATRIX,
+      summary: PRIVACY_POLICY_SUMMARY,
+    },
+  });
+};
+
+/**
+ * GET /compliance/payment-privacy-disclosure/:eventId
+ * Pre-payment disclosure for paid events (Standard vs Anonymous).
+ */
+export const getPaymentPrivacyDisclosure: RequestHandler = async (req, res) => {
+  try {
+    const eventId = Array.isArray(req.params.eventId)
+      ? req.params.eventId[0]
+      : req.params.eventId;
+
+    if (!eventId || !mongoose.Types.ObjectId.isValid(eventId)) {
+      return res.status(400).json({
+        error: 'Validation failed',
+        message: 'Invalid event ID',
+      });
+    }
+
+    const event = await EventTicket.findById(eventId)
+      .select('eventType paymentPrivacy name')
+      .lean();
+
+    if (!event) {
+      return res.status(404).json({
+        error: 'Not found',
+        message: 'Event not found',
+      });
+    }
+
+    const disclosure = PaymentPrivacyDisclosureService.buildDisclosure(
+      event.eventType,
+      event.paymentPrivacy,
+    );
+
+    res.status(200).json({
+      success: true,
+      data: {
+        eventId,
+        eventName: event.name,
+        paymentDisclosure: disclosure,
+      },
+    });
+  } catch (error) {
+    console.error('[PrivacyCompliance] getPaymentPrivacyDisclosure:', error);
+    res.status(500).json({
+      error: 'Internal server error',
+      message: 'Failed to load payment privacy disclosure',
+    });
+  }
+};

--- a/src/controllers/privacy-compliance.controller.ts
+++ b/src/controllers/privacy-compliance.controller.ts
@@ -4,6 +4,7 @@ import EventTicket from '../models/event-ticket';
 import {
   DATA_RETENTION_MATRIX,
   PRIVACY_POLICY_SUMMARY,
+  USER_FACING_PRIVACY_POLICY,
 } from '../constants/data-retention-matrix';
 import { PaymentPrivacyDisclosureService } from '../services/payment-privacy-disclosure.service';
 
@@ -18,6 +19,17 @@ export const getDataRetentionMatrix: RequestHandler = async (_req, res) => {
       matrix: DATA_RETENTION_MATRIX,
       summary: PRIVACY_POLICY_SUMMARY,
     },
+  });
+};
+
+/**
+ * GET /compliance/privacy-policy
+ * User-facing summary separating erasable off-chain data from permanent on-chain records.
+ */
+export const getPrivacyPolicy: RequestHandler = async (_req, res) => {
+  res.status(200).json({
+    success: true,
+    data: USER_FACING_PRIVACY_POLICY,
   });
 };
 

--- a/src/controllers/ticket-order.controller.ts
+++ b/src/controllers/ticket-order.controller.ts
@@ -107,6 +107,9 @@ export const verifyPayment: RequestHandler = async (
 
     const { txHash, eventTicketId, ticketType, quantity, expectedAmount } =
       req.body;
+    const privacyAcknowledged =
+      req.body.privacyAcknowledged === true ||
+      req.body.privacyAcknowledged === 'true';
 
     // ── Input validation ──────────────────────────────────────────────────────
     if (!txHash || typeof txHash !== 'string' || txHash.trim() === '') {
@@ -156,6 +159,9 @@ export const verifyPayment: RequestHandler = async (
       parsedQty,
       parsedAmount,
       idempotencyKey,
+      undefined,
+      undefined,
+      privacyAcknowledged,
     );
 
     if (!result.success) {

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -5,9 +5,30 @@ import {
   validateAndGetUser,
 } from '../utils/helper';
 
+/** Authenticates JWT and requires verified email for local accounts (issue #122). */
 const authGuard = async (req: UserAuthenticatedReq, res: any, next: any) => {
+  return authenticateRequest(req, res, next, { requireVerifiedEmail: true });
+};
+
+/**
+ * Authenticates JWT without requiring verified email.
+ * Used for right-to-erasure flows (issue #127).
+ */
+const authGuardIdentity = async (
+  req: UserAuthenticatedReq,
+  res: any,
+  next: any,
+) => {
+  return authenticateRequest(req, res, next, { requireVerifiedEmail: false });
+};
+
+async function authenticateRequest(
+  req: UserAuthenticatedReq,
+  res: any,
+  next: any,
+  options: { requireVerifiedEmail: boolean },
+) {
   try {
-    // Handle JWT guard (local & oauth)
     const token = extractToken(req);
     if (!token) {
       return res.status(401).json({
@@ -17,10 +38,11 @@ const authGuard = async (req: UserAuthenticatedReq, res: any, next: any) => {
 
     const user = await validateAndGetUser(token);
 
-    // Defense in depth: a valid JWT is not enough. Local accounts must have a
-    // verified email before reaching any protected route (see issue #122).
-    // Google accounts are verified by the provider and carry emailVerifiedAt.
-    if (user.provider === 'local' && !user.emailVerifiedAt) {
+    if (
+      options.requireVerifiedEmail &&
+      user.provider === 'local' &&
+      !user.emailVerifiedAt
+    ) {
       return res.status(403).json({
         error:
           'Forbidden: Please verify your email before accessing this resource',
@@ -33,6 +55,6 @@ const authGuard = async (req: UserAuthenticatedReq, res: any, next: any) => {
     const { error, code } = handleAuthError(err);
     return res.status(code).json({ error });
   }
-};
+}
 
-export { authGuard };
+export { authGuard, authGuardIdentity };

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -5,7 +5,9 @@ import {
   validateAndGetUser,
 } from '../utils/helper';
 
-/** Authenticates JWT and requires verified email for local accounts (issue #122). */
+/**
+ * Authenticates JWT and requires verified email for local accounts (issue #122).
+ */
 const authGuard = async (req: UserAuthenticatedReq, res: any, next: any) => {
   return authenticateRequest(req, res, next, { requireVerifiedEmail: true });
 };
@@ -22,6 +24,9 @@ const authGuardIdentity = async (
   return authenticateRequest(req, res, next, { requireVerifiedEmail: false });
 };
 
+/**
+ * Shared JWT authentication path; optionally enforces verified email for local users.
+ */
 async function authenticateRequest(
   req: UserAuthenticatedReq,
   res: any,

--- a/src/models/anonymization-job.ts
+++ b/src/models/anonymization-job.ts
@@ -26,6 +26,15 @@ anonymizationJobSchema.index(
   { expireAfterSeconds: 90 * 24 * 60 * 60 },
 );
 
+// One pending erasure job per user (atomic exclusivity for concurrent requests)
+anonymizationJobSchema.index(
+  { targetUserId: 1 },
+  {
+    unique: true,
+    partialFilterExpression: { status: 'pending' },
+  },
+);
+
 const AnonymizationJob = mongoose.model<IAnonymizationJob>(
   'AnonymizationJob',
   anonymizationJobSchema,

--- a/src/models/ticket-order.ts
+++ b/src/models/ticket-order.ts
@@ -14,6 +14,8 @@ export interface ITicketOrder extends Document {
   amount: number;
   zkIdMatch: boolean;
   privacyLevel: string;
+  /** Snapshot of event paymentPrivacy at purchase (0 anonymous, 1 standard). */
+  paymentPrivacy?: number | null;
   hasReceipt: boolean;
   datePurchased: Date;
   idempotencyKey?: string; // unique idempotency key for duplicate prevention
@@ -41,6 +43,7 @@ const ticketOrderSchema = new Schema<ITicketOrder>(
     amount: { type: Number, required: true, min: 0 },
     zkIdMatch: { type: Boolean, default: false },
     privacyLevel: { type: String, required: true },
+    paymentPrivacy: { type: Number, enum: [0, 1], default: null },
     hasReceipt: { type: Boolean, default: false },
     datePurchased: { type: Date, default: Date.now },
     idempotencyKey: { type: String, sparse: true, unique: true },

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -20,7 +20,7 @@ export interface IUser extends Document {
     emailOnTicketUpdate: boolean;
   };
   /** Set when the user exercises right-to-erasure (off-chain anonymization). */
-  anonymizedAt?: Date;
+  anonymizedAt?: Date | null;
 }
 
 const userSchema = new Schema<IUser>(

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -19,6 +19,8 @@ export interface IUser extends Document {
     emailOnTicketPurchase: boolean;
     emailOnTicketUpdate: boolean;
   };
+  /** Set when the user exercises right-to-erasure (off-chain anonymization). */
+  anonymizedAt?: Date;
 }
 
 const userSchema = new Schema<IUser>(
@@ -51,6 +53,7 @@ const userSchema = new Schema<IUser>(
       emailOnTicketPurchase: { type: Boolean, default: true },
       emailOnTicketUpdate: { type: Boolean, default: true },
     },
+    anonymizedAt: { type: Date, default: null },
   },
   { timestamps: true },
 );

--- a/src/routes/account.route.ts
+++ b/src/routes/account.route.ts
@@ -3,11 +3,15 @@ import {
   getErasureAssessment,
   requestErasure,
 } from '../controllers/account.controller';
-import { authGuard } from '../middlewares/auth';
+import { authGuardIdentity } from '../middlewares/auth';
 
 const accountRoutes = Router();
 
-accountRoutes.get('/erasure-assessment', authGuard, getErasureAssessment);
-accountRoutes.post('/request-erasure', authGuard, requestErasure);
+accountRoutes.get(
+  '/erasure-assessment',
+  authGuardIdentity,
+  getErasureAssessment,
+);
+accountRoutes.post('/request-erasure', authGuardIdentity, requestErasure);
 
 export default accountRoutes;

--- a/src/routes/account.route.ts
+++ b/src/routes/account.route.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import {
+  getErasureAssessment,
+  requestErasure,
+} from '../controllers/account.controller';
+import { authGuard } from '../middlewares/auth';
+
+const accountRoutes = Router();
+
+accountRoutes.get('/erasure-assessment', authGuard, getErasureAssessment);
+accountRoutes.post('/request-erasure', authGuard, requestErasure);
+
+export default accountRoutes;

--- a/src/routes/privacy-compliance.route.ts
+++ b/src/routes/privacy-compliance.route.ts
@@ -2,11 +2,13 @@ import { Router } from 'express';
 import {
   getDataRetentionMatrix,
   getPaymentPrivacyDisclosure,
+  getPrivacyPolicy,
 } from '../controllers/privacy-compliance.controller';
 
 const privacyComplianceRoutes = Router();
 
 privacyComplianceRoutes.get('/data-retention', getDataRetentionMatrix);
+privacyComplianceRoutes.get('/privacy-policy', getPrivacyPolicy);
 privacyComplianceRoutes.get(
   '/payment-privacy-disclosure/:eventId',
   getPaymentPrivacyDisclosure,

--- a/src/routes/privacy-compliance.route.ts
+++ b/src/routes/privacy-compliance.route.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import {
+  getDataRetentionMatrix,
+  getPaymentPrivacyDisclosure,
+} from '../controllers/privacy-compliance.controller';
+
+const privacyComplianceRoutes = Router();
+
+privacyComplianceRoutes.get('/data-retention', getDataRetentionMatrix);
+privacyComplianceRoutes.get(
+  '/payment-privacy-disclosure/:eventId',
+  getPaymentPrivacyDisclosure,
+);
+
+export default privacyComplianceRoutes;

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import emailWorker from './workers/email.worker';
 import zkEmailWorker from './workers/zkemail.worker';
 import paymentWorker from './workers/payment.worker';
 import reconciliationWorker from './workers/reconciliation.worker';
+import retentionWorker from './workers/retention.worker';
 import indexerWorker from './workers/indexer.worker';
 
 async function startServer() {
@@ -39,6 +40,9 @@ async function startServer() {
     // Reconciliation worker (periodic stale-tx cleanup via state machine)
     console.log('✓ Reconciliation worker initialized');
 
+    // Retention worker (TTL hygiene + anonymization job retries)
+    console.log('✓ Retention worker initialized');
+
     // Start Express server
     const server = app.listen(config.port, () => {
       console.log(`✓ Server running on port ${config.port}`);
@@ -53,6 +57,7 @@ async function startServer() {
         await zkEmailWorker.close();
         await paymentWorker.close();
         await reconciliationWorker.close();
+        await retentionWorker.close();
         await queueService.close();
         console.log('All services closed');
         process.exit(0);

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,9 @@ import emailWorker from './workers/email.worker';
 import zkEmailWorker from './workers/zkemail.worker';
 import paymentWorker from './workers/payment.worker';
 import reconciliationWorker from './workers/reconciliation.worker';
-import retentionWorker from './workers/retention.worker';
+import retentionWorker, {
+  initializeRetentionWorker,
+} from './workers/retention.worker';
 import indexerWorker from './workers/indexer.worker';
 
 async function startServer() {
@@ -41,6 +43,7 @@ async function startServer() {
     console.log('✓ Reconciliation worker initialized');
 
     // Retention worker (TTL hygiene + anonymization job retries)
+    await initializeRetentionWorker();
     console.log('✓ Retention worker initialized');
 
     // Start Express server

--- a/src/services/anonymization.service.ts
+++ b/src/services/anonymization.service.ts
@@ -20,6 +20,7 @@ const ANONYMIZED_EMAIL_DOMAIN = 'anonymized.zicket.local';
  * On-chain Soroban data is never modified.
  */
 export class AnonymizationService {
+  /** Submits an off-chain erasure request and runs anonymization for the user. */
   static async requestErasure(userId: string): Promise<AnonymizationResult> {
     if (!mongoose.Types.ObjectId.isValid(userId)) {
       throw new Error('Invalid user id');
@@ -34,18 +35,23 @@ export class AnonymizationService {
       throw new Error('Account has already been anonymized');
     }
 
-    const existingPending = await AnonymizationJob.findOne({
-      targetUserId: user._id,
-      status: 'pending',
-    });
-    if (existingPending) {
-      throw new Error('An erasure request is already in progress');
+    let job: IAnonymizationJob;
+    try {
+      job = await AnonymizationJob.create({
+        targetUserId: user._id,
+        status: 'pending',
+      });
+    } catch (error) {
+      if (
+        error &&
+        typeof error === 'object' &&
+        'code' in error &&
+        (error as { code: number }).code === 11000
+      ) {
+        throw new Error('An erasure request is already in progress');
+      }
+      throw error;
     }
-
-    const job = await AnonymizationJob.create({
-      targetUserId: user._id,
-      status: 'pending',
-    });
 
     return this.executeJob(job);
   }
@@ -99,6 +105,7 @@ export class AnonymizationService {
     }
   }
 
+  /** Anonymizes persisted PII on the user document (off-chain only). */
   private static async anonymizeUserDocument(
     user: InstanceType<typeof User>,
   ): Promise<void> {

--- a/src/services/anonymization.service.ts
+++ b/src/services/anonymization.service.ts
@@ -20,7 +20,9 @@ const ANONYMIZED_EMAIL_DOMAIN = 'anonymized.zicket.local';
  * On-chain Soroban data is never modified.
  */
 export class AnonymizationService {
-  /** Submits an off-chain erasure request and runs anonymization for the user. */
+  /**
+   * Submits an off-chain erasure request and runs anonymization for the user.
+   */
   static async requestErasure(userId: string): Promise<AnonymizationResult> {
     if (!mongoose.Types.ObjectId.isValid(userId)) {
       throw new Error('Invalid user id');
@@ -56,7 +58,9 @@ export class AnonymizationService {
     return this.executeJob(job);
   }
 
-  /** Processes a queued anonymization job (worker retry path). */
+  /**
+   * Processes a queued anonymization job (worker retry path).
+   */
   static async executeJob(
     job: IAnonymizationJob,
   ): Promise<AnonymizationResult> {
@@ -105,7 +109,9 @@ export class AnonymizationService {
     }
   }
 
-  /** Anonymizes persisted PII on the user document (off-chain only). */
+  /**
+   * Anonymizes persisted PII on the user document (off-chain only).
+   */
   private static async anonymizeUserDocument(
     user: InstanceType<typeof User>,
   ): Promise<void> {

--- a/src/services/anonymization.service.ts
+++ b/src/services/anonymization.service.ts
@@ -1,0 +1,127 @@
+import mongoose from 'mongoose';
+import User from '../models/user';
+import AnonymizationJob, {
+  IAnonymizationJob,
+} from '../models/anonymization-job';
+import { ErasureAssessmentService } from './erasure-assessment.service';
+
+export interface AnonymizationResult {
+  userId: string;
+  jobId: string;
+  status: 'completed' | 'failed';
+  assessment: Awaited<ReturnType<typeof ErasureAssessmentService.assessUser>>;
+  message: string;
+}
+
+const ANONYMIZED_EMAIL_DOMAIN = 'anonymized.zicket.local';
+
+/**
+ * Off-chain user erasure / anonymization (Issue #127).
+ * On-chain Soroban data is never modified.
+ */
+export class AnonymizationService {
+  static async requestErasure(userId: string): Promise<AnonymizationResult> {
+    if (!mongoose.Types.ObjectId.isValid(userId)) {
+      throw new Error('Invalid user id');
+    }
+
+    const user = await User.findById(userId);
+    if (!user) {
+      throw new Error('User not found');
+    }
+
+    if (user.anonymizedAt) {
+      throw new Error('Account has already been anonymized');
+    }
+
+    const existingPending = await AnonymizationJob.findOne({
+      targetUserId: user._id,
+      status: 'pending',
+    });
+    if (existingPending) {
+      throw new Error('An erasure request is already in progress');
+    }
+
+    const job = await AnonymizationJob.create({
+      targetUserId: user._id,
+      status: 'pending',
+    });
+
+    return this.executeJob(job);
+  }
+
+  /** Processes a queued anonymization job (worker retry path). */
+  static async executeJob(
+    job: IAnonymizationJob,
+  ): Promise<AnonymizationResult> {
+    const userId = job.targetUserId.toString();
+    const user = await User.findById(job.targetUserId);
+
+    if (!user) {
+      job.status = 'failed';
+      await job.save();
+      throw new Error('User not found for anonymization job');
+    }
+
+    if (user.anonymizedAt) {
+      job.status = 'completed';
+      await job.save();
+      const assessment = await ErasureAssessmentService.assessUser(userId);
+      return {
+        userId,
+        jobId: (job._id as mongoose.Types.ObjectId).toString(),
+        status: 'completed',
+        assessment,
+        message: 'Account was already anonymized',
+      };
+    }
+
+    const assessment = await ErasureAssessmentService.assessUser(userId);
+
+    try {
+      await this.anonymizeUserDocument(user);
+      job.status = 'completed';
+      await job.save();
+
+      return {
+        userId,
+        jobId: (job._id as mongoose.Types.ObjectId).toString(),
+        status: 'completed',
+        assessment,
+        message: assessment.onChainPermanentData
+          ? 'Off-chain profile data anonymized. On-chain payment records remain permanent as disclosed.'
+          : 'Off-chain profile data anonymized. No Standard-payment on-chain wallet records found.',
+      };
+    } catch (error) {
+      job.status = 'failed';
+      await job.save();
+      throw error;
+    }
+  }
+
+  private static async anonymizeUserDocument(
+    user: InstanceType<typeof User>,
+  ): Promise<void> {
+    const objectId = (user._id as mongoose.Types.ObjectId).toString();
+
+    user.name = 'Deleted User';
+    user.email = `deleted+${objectId}@${ANONYMIZED_EMAIL_DOMAIN}`;
+    user.password = undefined;
+    user.googleId = undefined;
+    user.otp = undefined;
+    user.otpExpires = undefined;
+    user.magicToken = undefined;
+    user.magicTokenExpires = undefined;
+    user.zkEmail = undefined;
+    user.zkPassport = undefined;
+    user.zkEmailVerified = false;
+    user.zkPassportVerified = false;
+    user.anonymizedAt = new Date();
+    user.notificationPreferences = {
+      emailOnTicketPurchase: false,
+      emailOnTicketUpdate: false,
+    };
+
+    await user.save();
+  }
+}

--- a/src/services/data-retention.service.ts
+++ b/src/services/data-retention.service.ts
@@ -18,6 +18,7 @@ const STALE_PENDING_MS = 60_000;
  * Operational retention pass — TTL-backed collections and stuck erasure jobs.
  */
 export class DataRetentionService {
+  /** Runs a scheduled retention pass over TTL collections and stuck erasure jobs. */
   static async runRetentionPass(): Promise<RetentionReport> {
     const startTime = Date.now();
 
@@ -30,8 +31,8 @@ export class DataRetentionService {
         AnonymizationJob.find({
           status: 'pending',
           createdAt: { $lt: staleThreshold },
-        }).lean(),
-        AnonymizationJob.find({ status: 'failed' }).lean(),
+        }),
+        AnonymizationJob.find({ status: 'failed' }),
       ]);
 
     const jobsToProcess = [...pendingJobs, ...failedJobs];
@@ -40,7 +41,7 @@ export class DataRetentionService {
 
     for (const job of jobsToProcess) {
       try {
-        await AnonymizationService.executeJob(job as any);
+        await AnonymizationService.executeJob(job);
         anonymizationJobsProcessed++;
       } catch {
         anonymizationJobsFailed++;

--- a/src/services/data-retention.service.ts
+++ b/src/services/data-retention.service.ts
@@ -18,7 +18,9 @@ const STALE_PENDING_MS = 60_000;
  * Operational retention pass — TTL-backed collections and stuck erasure jobs.
  */
 export class DataRetentionService {
-  /** Runs a scheduled retention pass over TTL collections and stuck erasure jobs. */
+  /**
+   * Runs a scheduled retention pass over TTL collections and stuck erasure jobs.
+   */
   static async runRetentionPass(): Promise<RetentionReport> {
     const startTime = Date.now();
 

--- a/src/services/data-retention.service.ts
+++ b/src/services/data-retention.service.ts
@@ -1,0 +1,59 @@
+import AnonymizationJob from '../models/anonymization-job';
+import TempData from '../models/temp-data';
+import Log from '../models/log';
+import { AnonymizationService } from './anonymization.service';
+
+export interface RetentionReport {
+  tempDataCount: number;
+  logCount: number;
+  pendingAnonymizationJobs: number;
+  anonymizationJobsProcessed: number;
+  anonymizationJobsFailed: number;
+  durationMs: number;
+}
+
+const STALE_PENDING_MS = 60_000;
+
+/**
+ * Operational retention pass — TTL-backed collections and stuck erasure jobs.
+ */
+export class DataRetentionService {
+  static async runRetentionPass(): Promise<RetentionReport> {
+    const startTime = Date.now();
+
+    const staleThreshold = new Date(Date.now() - STALE_PENDING_MS);
+
+    const [tempDataCount, logCount, pendingJobs, failedJobs] =
+      await Promise.all([
+        TempData.estimatedDocumentCount(),
+        Log.estimatedDocumentCount(),
+        AnonymizationJob.find({
+          status: 'pending',
+          createdAt: { $lt: staleThreshold },
+        }).lean(),
+        AnonymizationJob.find({ status: 'failed' }).lean(),
+      ]);
+
+    const jobsToProcess = [...pendingJobs, ...failedJobs];
+    let anonymizationJobsProcessed = 0;
+    let anonymizationJobsFailed = 0;
+
+    for (const job of jobsToProcess) {
+      try {
+        await AnonymizationService.executeJob(job as any);
+        anonymizationJobsProcessed++;
+      } catch {
+        anonymizationJobsFailed++;
+      }
+    }
+
+    return {
+      tempDataCount,
+      logCount,
+      pendingAnonymizationJobs: pendingJobs.length,
+      anonymizationJobsProcessed,
+      anonymizationJobsFailed,
+      durationMs: Date.now() - startTime,
+    };
+  }
+}

--- a/src/services/erasure-assessment.service.ts
+++ b/src/services/erasure-assessment.service.ts
@@ -17,7 +17,9 @@ export interface ErasureAssessment {
  * Assesses right-to-erasure impact: off-chain vs immutable on-chain data (Issue #127).
  */
 export class ErasureAssessmentService {
-  /** Evaluates whether a user has erasable off-chain data or permanent on-chain wallet exposure. */
+  /**
+   * Evaluates whether a user has erasable off-chain data or permanent on-chain wallet exposure.
+   */
   static async assessUser(userId: string): Promise<ErasureAssessment> {
     if (!mongoose.Types.ObjectId.isValid(userId)) {
       throw new Error('Invalid user id');

--- a/src/services/erasure-assessment.service.ts
+++ b/src/services/erasure-assessment.service.ts
@@ -1,0 +1,76 @@
+import mongoose from 'mongoose';
+import TicketOrder from '../models/ticket-order';
+import EventTicket from '../models/event-ticket';
+import { PAYMENT_PRIVACY_STANDARD } from './payment-privacy-disclosure.service';
+
+export interface ErasureAssessment {
+  userId: string;
+  offChainErasable: boolean;
+  onChainPermanentData: boolean;
+  onChainPermanentReasons: string[];
+  ordersReviewed: number;
+  standardPaymentOrders: number;
+  anonymousOnlyPaymentHistory: boolean;
+}
+
+/**
+ * Assesses right-to-erasure impact: off-chain vs immutable on-chain data (Issue #127).
+ */
+export class ErasureAssessmentService {
+  static async assessUser(userId: string): Promise<ErasureAssessment> {
+    if (!mongoose.Types.ObjectId.isValid(userId)) {
+      throw new Error('Invalid user id');
+    }
+
+    const orders = await TicketOrder.find({
+      user: new mongoose.Types.ObjectId(userId),
+    })
+      .select('eventTicket paymentPrivacy')
+      .lean();
+
+    const eventIds = [...new Set(orders.map((o) => o.eventTicket.toString()))];
+
+    const events =
+      eventIds.length > 0
+        ? await EventTicket.find({ _id: { $in: eventIds } })
+            .select('eventType paymentPrivacy name')
+            .lean()
+        : [];
+
+    const eventById = new Map(events.map((e) => [e._id.toString(), e]));
+
+    const onChainPermanentReasons: string[] = [];
+    let standardPaymentOrders = 0;
+
+    for (const order of orders) {
+      const event = eventById.get(order.eventTicket.toString());
+      if (!event || event.eventType !== 1) {
+        continue;
+      }
+
+      const effectivePrivacy =
+        order.paymentPrivacy ?? event.paymentPrivacy ?? null;
+
+      if (effectivePrivacy === PAYMENT_PRIVACY_STANDARD) {
+        standardPaymentOrders++;
+        onChainPermanentReasons.push(
+          `Standard payment for event "${event.name}": wallet address is stored permanently on Soroban PaymentRecord`,
+        );
+      }
+    }
+
+    const onChainPermanentData = standardPaymentOrders > 0;
+    const anonymousOnlyPaymentHistory =
+      orders.length > 0 && standardPaymentOrders === 0;
+
+    return {
+      userId,
+      offChainErasable: true,
+      onChainPermanentData,
+      onChainPermanentReasons,
+      ordersReviewed: orders.length,
+      standardPaymentOrders,
+      anonymousOnlyPaymentHistory,
+    };
+  }
+}

--- a/src/services/erasure-assessment.service.ts
+++ b/src/services/erasure-assessment.service.ts
@@ -17,6 +17,7 @@ export interface ErasureAssessment {
  * Assesses right-to-erasure impact: off-chain vs immutable on-chain data (Issue #127).
  */
 export class ErasureAssessmentService {
+  /** Evaluates whether a user has erasable off-chain data or permanent on-chain wallet exposure. */
   static async assessUser(userId: string): Promise<ErasureAssessment> {
     if (!mongoose.Types.ObjectId.isValid(userId)) {
       throw new Error('Invalid user id');
@@ -41,12 +42,15 @@ export class ErasureAssessmentService {
 
     const onChainPermanentReasons: string[] = [];
     let standardPaymentOrders = 0;
+    let paidOrdersReviewed = 0;
 
     for (const order of orders) {
       const event = eventById.get(order.eventTicket.toString());
       if (!event || event.eventType !== 1) {
         continue;
       }
+
+      paidOrdersReviewed++;
 
       const effectivePrivacy =
         order.paymentPrivacy ?? event.paymentPrivacy ?? null;
@@ -61,14 +65,14 @@ export class ErasureAssessmentService {
 
     const onChainPermanentData = standardPaymentOrders > 0;
     const anonymousOnlyPaymentHistory =
-      orders.length > 0 && standardPaymentOrders === 0;
+      paidOrdersReviewed > 0 && standardPaymentOrders === 0;
 
     return {
       userId,
       offChainErasable: true,
       onChainPermanentData,
       onChainPermanentReasons,
-      ordersReviewed: orders.length,
+      ordersReviewed: paidOrdersReviewed,
       standardPaymentOrders,
       anonymousOnlyPaymentHistory,
     };

--- a/src/services/payment-privacy-disclosure.service.ts
+++ b/src/services/payment-privacy-disclosure.service.ts
@@ -1,0 +1,100 @@
+/**
+ * Pre-payment privacy disclosures for paid events (Issue #127).
+ * paymentPrivacy: 0 = Anonymous, 1 = Standard/Public (wallet on-chain).
+ */
+
+export const PAYMENT_PRIVACY_ANONYMOUS = 0;
+export const PAYMENT_PRIVACY_STANDARD = 1;
+
+export interface PaymentPrivacyDisclosure {
+  required: boolean;
+  paymentPrivacy: number | null;
+  level: 'anonymous' | 'standard' | 'not_applicable';
+  onChainWalletStored: boolean;
+  onChainDataPermanent: boolean;
+  warning: string | null;
+  acknowledgmentRequired: boolean;
+  policyReference: string;
+}
+
+const STANDARD_WARNING =
+  'This event uses Standard (public) payment privacy. Your paying wallet address ' +
+  'will be stored on the Stellar/Soroban blockchain as part of the payment record. ' +
+  'Blockchain data is permanent and cannot be erased, including under right-to-erasure requests. ' +
+  'By proceeding you acknowledge this limitation.';
+
+const ANONYMOUS_NOTICE =
+  'This event uses Anonymous payment privacy. Your wallet address is not stored ' +
+  'in the on-chain PaymentRecord. Off-chain account data remains subject to our erasure policy.';
+
+export class PaymentPrivacyDisclosureService {
+  /**
+   * Builds the disclosure payload shown before payment for a paid event.
+   */
+  static buildDisclosure(
+    eventType: number,
+    paymentPrivacy?: number | null,
+  ): PaymentPrivacyDisclosure {
+    if (eventType !== 1) {
+      return {
+        required: false,
+        paymentPrivacy: paymentPrivacy ?? null,
+        level: 'not_applicable',
+        onChainWalletStored: false,
+        onChainDataPermanent: false,
+        warning: null,
+        acknowledgmentRequired: false,
+        policyReference: '/compliance/data-retention',
+      };
+    }
+
+    const level =
+      paymentPrivacy === PAYMENT_PRIVACY_STANDARD ? 'standard' : 'anonymous';
+
+    if (paymentPrivacy === PAYMENT_PRIVACY_STANDARD) {
+      return {
+        required: true,
+        paymentPrivacy,
+        level,
+        onChainWalletStored: true,
+        onChainDataPermanent: true,
+        warning: STANDARD_WARNING,
+        acknowledgmentRequired: true,
+        policyReference: '/compliance/data-retention',
+      };
+    }
+
+    return {
+      required: true,
+      paymentPrivacy: paymentPrivacy ?? PAYMENT_PRIVACY_ANONYMOUS,
+      level,
+      onChainWalletStored: false,
+      onChainDataPermanent: false,
+      warning: ANONYMOUS_NOTICE,
+      acknowledgmentRequired: false,
+      policyReference: '/compliance/data-retention',
+    };
+  }
+
+  /**
+   * Returns an error message when Standard payment proceeds without acknowledgment.
+   */
+  static validateAcknowledgment(
+    eventType: number,
+    paymentPrivacy: number | null | undefined,
+    privacyAcknowledged?: boolean,
+  ): string | null {
+    const disclosure = this.buildDisclosure(eventType, paymentPrivacy);
+    if (!disclosure.acknowledgmentRequired) {
+      return null;
+    }
+    if (privacyAcknowledged !== true) {
+      return (
+        'privacyAcknowledged must be true before paying for Standard (public) ' +
+        'payment events. Review GET /compliance/payment-privacy-disclosure/:eventId ' +
+        'or the event paymentDisclosure field.'
+      );
+    }
+    return null;
+  }
+}

--- a/src/services/payment-privacy-disclosure.service.ts
+++ b/src/services/payment-privacy-disclosure.service.ts
@@ -24,8 +24,9 @@ const STANDARD_WARNING =
   'By proceeding you acknowledge this limitation.';
 
 const ANONYMOUS_NOTICE =
-  'This event uses Anonymous payment privacy. Your wallet address is not stored ' +
-  'in the on-chain PaymentRecord. Off-chain account data remains subject to our erasure policy.';
+  'This event uses Anonymous payment privacy. A permanent Soroban PaymentRecord is still ' +
+  'created on-chain, but your paying wallet address is not stored in that record. ' +
+  'Off-chain account data remains subject to our erasure policy.';
 
 export class PaymentPrivacyDisclosureService {
   /**
@@ -69,7 +70,7 @@ export class PaymentPrivacyDisclosureService {
       paymentPrivacy: paymentPrivacy ?? PAYMENT_PRIVACY_ANONYMOUS,
       level,
       onChainWalletStored: false,
-      onChainDataPermanent: false,
+      onChainDataPermanent: true,
       warning: ANONYMOUS_NOTICE,
       acknowledgmentRequired: false,
       policyReference: '/compliance/data-retention',

--- a/src/verification/payment-verification.service.ts
+++ b/src/verification/payment-verification.service.ts
@@ -11,6 +11,7 @@ import {
   ZkProviderType,
 } from '../services/zk-orchestrator.service';
 import { TransactionStateMachine } from '../state-machine/transaction.state-machine';
+import { PaymentPrivacyDisclosureService } from '../services/payment-privacy-disclosure.service';
 
 /**
  * Orchestrates payment verification (delegated to PaymentVerificationService)
@@ -56,6 +57,7 @@ export class PaymentVerificationService {
     idempotencyKey?: string,
     zkProofPayload?: ZkProofPayload,
     zkProvider?: ZkProviderType,
+    privacyAcknowledged?: boolean,
   ): Promise<VerificationResult> {
     // ── 1. Idempotency guard: check if this request was already processed ─────
     if (idempotencyKey) {
@@ -90,6 +92,15 @@ export class PaymentVerificationService {
     const event = await EventTicket.findById(eventTicketId);
     if (!event) {
       return { success: false, message: 'Event not found' };
+    }
+
+    const ackError = PaymentPrivacyDisclosureService.validateAcknowledgment(
+      event.eventType,
+      event.paymentPrivacy,
+      privacyAcknowledged,
+    );
+    if (ackError) {
+      return { success: false, message: ackError };
     }
 
     // ── 4. Privacy enforcement ────────────────────────────────────────────────
@@ -211,6 +222,7 @@ export class PaymentVerificationService {
             amount: expectedAmountUsd,
             zkIdMatch: !!zkProofPayload,
             privacyLevel: String(event.privacyLevel),
+            paymentPrivacy: event.paymentPrivacy ?? null,
             hasReceipt: event.offerReceipts ?? false,
             datePurchased: new Date(),
             idempotencyKey: idempotencyKey || undefined,

--- a/src/workers/retention.worker.ts
+++ b/src/workers/retention.worker.ts
@@ -24,7 +24,9 @@ export const retentionQueue = new Queue(QUEUE_NAMES.RETENTION, {
   },
 });
 
-/** Registers the repeatable retention cron after env validation (server startup). */
+/**
+ * Registers the repeatable retention cron after env validation (server startup).
+ */
 export async function initializeRetentionWorker(): Promise<void> {
   const { name, opts } = REPEATABLE_JOBS.RUN_RETENTION_PASS;
 

--- a/src/workers/retention.worker.ts
+++ b/src/workers/retention.worker.ts
@@ -1,0 +1,92 @@
+import { Worker, Queue, Job } from 'bullmq';
+import { redisConfig } from '../config/queue';
+import {
+  QUEUE_NAMES,
+  RetentionJobType,
+  RetentionPayload,
+  REPEATABLE_JOBS,
+} from '../config/queue-jobs';
+import { DataRetentionService } from '../services/data-retention.service';
+
+/**
+ * #127 — Retention Worker
+ *
+ * Daily pass over TTL-backed collections and stuck anonymization jobs.
+ */
+
+export const retentionQueue = new Queue(QUEUE_NAMES.RETENTION, {
+  connection: redisConfig as any,
+  defaultJobOptions: {
+    attempts: 2,
+    backoff: { type: 'fixed', delay: 60_000 },
+    removeOnComplete: { age: 3600 },
+    removeOnFail: { age: 86400 },
+  },
+});
+
+(async () => {
+  try {
+    const { name, opts } = REPEATABLE_JOBS.RUN_RETENTION_PASS;
+
+    await retentionQueue.add(
+      name,
+      { triggeredBy: 'schedule', timestamp: Date.now() } as RetentionPayload,
+      opts,
+    );
+
+    console.log(
+      `[RetentionWorker] Repeatable job registered — pattern: ${opts.repeat.pattern}`,
+    );
+  } catch (err) {
+    console.error('[RetentionWorker] Failed to register repeatable job:', err);
+  }
+})();
+
+const retentionWorker = new Worker(
+  QUEUE_NAMES.RETENTION,
+  async (job: Job<RetentionPayload>) => {
+    const { name, data } = job;
+
+    console.log(
+      `[RetentionWorker] Starting run — triggeredBy: ${data.triggeredBy}`,
+    );
+
+    switch (name as RetentionJobType) {
+      case RetentionJobType.RUN_RETENTION_PASS: {
+        const report = await DataRetentionService.runRetentionPass();
+        return report;
+      }
+
+      default:
+        console.warn(`[RetentionWorker] Unknown job type: ${name}`);
+    }
+  },
+  {
+    connection: redisConfig as any,
+    concurrency: 1,
+    removeOnComplete: { age: 3600 },
+    removeOnFail: { age: 86400 },
+  },
+);
+
+retentionWorker.on('completed', (job, result) => {
+  const r = result as any;
+  if (r) {
+    console.log(
+      `[RetentionWorker] ✓ Run complete — tempData: ${r.tempDataCount}, ` +
+        `logs: ${r.logCount}, pendingJobs: ${r.pendingAnonymizationJobs}, ` +
+        `processed: ${r.anonymizationJobsProcessed}, ` +
+        `failed: ${r.anonymizationJobsFailed}, duration: ${r.durationMs}ms`,
+    );
+  }
+});
+
+retentionWorker.on('failed', (job, err) => {
+  console.error(`[RetentionWorker] Job ${job?.id} failed: ${err.message}`);
+});
+
+retentionWorker.on('error', (err) => {
+  console.error('[RetentionWorker] Worker error:', err);
+});
+
+export default retentionWorker;

--- a/src/workers/retention.worker.ts
+++ b/src/workers/retention.worker.ts
@@ -24,23 +24,20 @@ export const retentionQueue = new Queue(QUEUE_NAMES.RETENTION, {
   },
 });
 
-(async () => {
-  try {
-    const { name, opts } = REPEATABLE_JOBS.RUN_RETENTION_PASS;
+/** Registers the repeatable retention cron after env validation (server startup). */
+export async function initializeRetentionWorker(): Promise<void> {
+  const { name, opts } = REPEATABLE_JOBS.RUN_RETENTION_PASS;
 
-    await retentionQueue.add(
-      name,
-      { triggeredBy: 'schedule', timestamp: Date.now() } as RetentionPayload,
-      opts,
-    );
+  await retentionQueue.add(
+    name,
+    { triggeredBy: 'schedule', timestamp: Date.now() } as RetentionPayload,
+    opts,
+  );
 
-    console.log(
-      `[RetentionWorker] Repeatable job registered — pattern: ${opts.repeat.pattern}`,
-    );
-  } catch (err) {
-    console.error('[RetentionWorker] Failed to register repeatable job:', err);
-  }
-})();
+  console.log(
+    `[RetentionWorker] Repeatable job registered — pattern: ${opts.repeat.pattern}`,
+  );
+}
 
 const retentionWorker = new Worker(
   QUEUE_NAMES.RETENTION,

--- a/tests/anonymization.service.test.ts
+++ b/tests/anonymization.service.test.ts
@@ -1,0 +1,92 @@
+import mongoose from 'mongoose';
+import { AnonymizationService } from '../src/services/anonymization.service';
+import User from '../src/models/user';
+import AnonymizationJob from '../src/models/anonymization-job';
+import { ErasureAssessmentService } from '../src/services/erasure-assessment.service';
+
+jest.mock('../src/models/user');
+jest.mock('../src/models/anonymization-job');
+jest.mock('../src/services/erasure-assessment.service');
+
+const mockUser = User as jest.Mocked<typeof User>;
+const mockAnonymizationJob = AnonymizationJob as jest.Mocked<
+  typeof AnonymizationJob
+>;
+const mockErasureAssessment = ErasureAssessmentService as jest.Mocked<
+  typeof ErasureAssessmentService
+>;
+
+describe('AnonymizationService', () => {
+  const userId = new mongoose.Types.ObjectId();
+  const jobId = new mongoose.Types.ObjectId();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('anonymizes user profile and completes job', async () => {
+    const saveUser = jest.fn().mockResolvedValue(undefined);
+    const userDoc = {
+      _id: userId,
+      name: 'Alice',
+      email: 'alice@example.com',
+      password: 'hash',
+      anonymizedAt: undefined,
+      save: saveUser,
+    };
+
+    (mockUser.findById as jest.Mock).mockResolvedValue(userDoc);
+    (mockAnonymizationJob.findOne as jest.Mock).mockResolvedValue(null);
+    (mockAnonymizationJob.create as jest.Mock).mockResolvedValue({
+      _id: jobId,
+      targetUserId: userId,
+      status: 'pending',
+      save: jest.fn().mockResolvedValue(undefined),
+    });
+
+    mockErasureAssessment.assessUser.mockResolvedValue({
+      userId: userId.toString(),
+      offChainErasable: true,
+      onChainPermanentData: false,
+      onChainPermanentReasons: [],
+      ordersReviewed: 0,
+      standardPaymentOrders: 0,
+      anonymousOnlyPaymentHistory: false,
+    });
+
+    const result = await AnonymizationService.requestErasure(userId.toString());
+
+    expect(result.status).toBe('completed');
+    expect(saveUser).toHaveBeenCalled();
+    expect(userDoc.name).toBe('Deleted User');
+    expect(userDoc.email).toMatch(/deleted\+.*@anonymized\.zicket\.local/);
+    expect(userDoc.password).toBeUndefined();
+    expect(userDoc.anonymizedAt).toBeInstanceOf(Date);
+  });
+
+  it('rejects duplicate erasure for already anonymized accounts', async () => {
+    (mockUser.findById as jest.Mock).mockResolvedValue({
+      _id: userId,
+      anonymizedAt: new Date(),
+    });
+
+    await expect(
+      AnonymizationService.requestErasure(userId.toString()),
+    ).rejects.toThrow('Account has already been anonymized');
+  });
+
+  it('rejects when a pending job already exists', async () => {
+    (mockUser.findById as jest.Mock).mockResolvedValue({
+      _id: userId,
+      anonymizedAt: undefined,
+    });
+    (mockAnonymizationJob.findOne as jest.Mock).mockResolvedValue({
+      _id: jobId,
+      status: 'pending',
+    });
+
+    await expect(
+      AnonymizationService.requestErasure(userId.toString()),
+    ).rejects.toThrow('An erasure request is already in progress');
+  });
+});

--- a/tests/anonymization.service.test.ts
+++ b/tests/anonymization.service.test.ts
@@ -36,7 +36,6 @@ describe('AnonymizationService', () => {
     };
 
     (mockUser.findById as jest.Mock).mockResolvedValue(userDoc);
-    (mockAnonymizationJob.findOne as jest.Mock).mockResolvedValue(null);
     (mockAnonymizationJob.create as jest.Mock).mockResolvedValue({
       _id: jobId,
       targetUserId: userId,
@@ -75,14 +74,13 @@ describe('AnonymizationService', () => {
     ).rejects.toThrow('Account has already been anonymized');
   });
 
-  it('rejects when a pending job already exists', async () => {
+  it('rejects when a pending job already exists (duplicate key)', async () => {
     (mockUser.findById as jest.Mock).mockResolvedValue({
       _id: userId,
       anonymizedAt: undefined,
     });
-    (mockAnonymizationJob.findOne as jest.Mock).mockResolvedValue({
-      _id: jobId,
-      status: 'pending',
+    (mockAnonymizationJob.create as jest.Mock).mockRejectedValue({
+      code: 11000,
     });
 
     await expect(

--- a/tests/data-retention.service.test.ts
+++ b/tests/data-retention.service.test.ts
@@ -27,18 +27,23 @@ describe('DataRetentionService', () => {
     const staleJob = { _id: 'job1', targetUserId: 'user1', status: 'pending' };
     const failedJob = { _id: 'job2', targetUserId: 'user2', status: 'failed' };
 
+    const saveMock = jest.fn().mockResolvedValue(undefined);
+    const hydratedJob = (raw: { _id: string; targetUserId: string }) => ({
+      ...raw,
+      status: 'pending',
+      save: saveMock,
+    });
+
     (mockAnonymizationJob.find as jest.Mock).mockImplementation(
-      (query: { status?: string }) => ({
-        lean: jest
-          .fn()
-          .mockResolvedValue(
-            query.status === 'pending'
-              ? [staleJob]
-              : query.status === 'failed'
-                ? [failedJob]
-                : [],
-          ),
-      }),
+      (query: { status?: string }) => {
+        const jobs =
+          query.status === 'pending'
+            ? [staleJob]
+            : query.status === 'failed'
+              ? [failedJob]
+              : [];
+        return Promise.resolve(jobs.map((j) => hydratedJob(j)));
+      },
     );
 
     (AnonymizationService.executeJob as jest.Mock).mockResolvedValue({

--- a/tests/data-retention.service.test.ts
+++ b/tests/data-retention.service.test.ts
@@ -1,0 +1,56 @@
+import { DataRetentionService } from '../src/services/data-retention.service';
+import AnonymizationJob from '../src/models/anonymization-job';
+import TempData from '../src/models/temp-data';
+import Log from '../src/models/log';
+import { AnonymizationService } from '../src/services/anonymization.service';
+
+jest.mock('../src/models/anonymization-job');
+jest.mock('../src/models/temp-data');
+jest.mock('../src/models/log');
+jest.mock('../src/services/anonymization.service');
+
+const mockAnonymizationJob = AnonymizationJob as jest.Mocked<
+  typeof AnonymizationJob
+>;
+const mockTempData = TempData as jest.Mocked<typeof TempData>;
+const mockLog = Log as jest.Mocked<typeof Log>;
+
+describe('DataRetentionService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reports collection counts and retries stale jobs', async () => {
+    mockTempData.estimatedDocumentCount.mockResolvedValue(3);
+    mockLog.estimatedDocumentCount.mockResolvedValue(12);
+
+    const staleJob = { _id: 'job1', targetUserId: 'user1', status: 'pending' };
+    const failedJob = { _id: 'job2', targetUserId: 'user2', status: 'failed' };
+
+    (mockAnonymizationJob.find as jest.Mock).mockImplementation(
+      (query: { status?: string }) => ({
+        lean: jest
+          .fn()
+          .mockResolvedValue(
+            query.status === 'pending'
+              ? [staleJob]
+              : query.status === 'failed'
+                ? [failedJob]
+                : [],
+          ),
+      }),
+    );
+
+    (AnonymizationService.executeJob as jest.Mock).mockResolvedValue({
+      status: 'completed',
+    });
+
+    const report = await DataRetentionService.runRetentionPass();
+
+    expect(report.tempDataCount).toBe(3);
+    expect(report.logCount).toBe(12);
+    expect(report.pendingAnonymizationJobs).toBe(1);
+    expect(report.anonymizationJobsProcessed).toBe(2);
+    expect(AnonymizationService.executeJob).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/erasure-assessment.service.test.ts
+++ b/tests/erasure-assessment.service.test.ts
@@ -1,0 +1,161 @@
+import mongoose from 'mongoose';
+import { ErasureAssessmentService } from '../src/services/erasure-assessment.service';
+import TicketOrder from '../src/models/ticket-order';
+import EventTicket from '../src/models/event-ticket';
+import {
+  PAYMENT_PRIVACY_ANONYMOUS,
+  PAYMENT_PRIVACY_STANDARD,
+} from '../src/services/payment-privacy-disclosure.service';
+
+jest.mock('../src/models/ticket-order');
+jest.mock('../src/models/event-ticket');
+
+const mockTicketOrder = TicketOrder as jest.Mocked<typeof TicketOrder>;
+const mockEventTicket = EventTicket as jest.Mocked<typeof EventTicket>;
+
+const userId = new mongoose.Types.ObjectId().toString();
+
+describe('ErasureAssessmentService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reports anonymous-only history with no on-chain permanent data', async () => {
+    const eventId = new mongoose.Types.ObjectId();
+
+    (mockTicketOrder.find as jest.Mock).mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          {
+            eventTicket: eventId,
+            paymentPrivacy: PAYMENT_PRIVACY_ANONYMOUS,
+          },
+        ]),
+      }),
+    });
+
+    (mockEventTicket.find as jest.Mock).mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          {
+            _id: eventId,
+            name: 'Anon Fest',
+            eventType: 1,
+            paymentPrivacy: PAYMENT_PRIVACY_ANONYMOUS,
+          },
+        ]),
+      }),
+    });
+
+    const assessment = await ErasureAssessmentService.assessUser(userId);
+
+    expect(assessment.onChainPermanentData).toBe(false);
+    expect(assessment.anonymousOnlyPaymentHistory).toBe(true);
+    expect(assessment.onChainPermanentReasons).toHaveLength(0);
+    expect(assessment.offChainErasable).toBe(true);
+  });
+
+  it('flags Standard payment history as permanent on-chain', async () => {
+    const eventId = new mongoose.Types.ObjectId();
+
+    (mockTicketOrder.find as jest.Mock).mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          {
+            eventTicket: eventId,
+            paymentPrivacy: PAYMENT_PRIVACY_STANDARD,
+          },
+        ]),
+      }),
+    });
+
+    (mockEventTicket.find as jest.Mock).mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          {
+            _id: eventId,
+            name: 'Public Gala',
+            eventType: 1,
+            paymentPrivacy: PAYMENT_PRIVACY_STANDARD,
+          },
+        ]),
+      }),
+    });
+
+    const assessment = await ErasureAssessmentService.assessUser(userId);
+
+    expect(assessment.onChainPermanentData).toBe(true);
+    expect(assessment.standardPaymentOrders).toBe(1);
+    expect(assessment.anonymousOnlyPaymentHistory).toBe(false);
+    expect(assessment.onChainPermanentReasons[0]).toMatch(/Public Gala/);
+    expect(assessment.onChainPermanentReasons[0]).toMatch(
+      /Soroban PaymentRecord/,
+    );
+  });
+
+  it('falls back to event paymentPrivacy when order snapshot is missing', async () => {
+    const eventId = new mongoose.Types.ObjectId();
+
+    (mockTicketOrder.find as jest.Mock).mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          {
+            eventTicket: eventId,
+            paymentPrivacy: null,
+          },
+        ]),
+      }),
+    });
+
+    (mockEventTicket.find as jest.Mock).mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          {
+            _id: eventId,
+            name: 'Legacy Order Event',
+            eventType: 1,
+            paymentPrivacy: PAYMENT_PRIVACY_STANDARD,
+          },
+        ]),
+      }),
+    });
+
+    const assessment = await ErasureAssessmentService.assessUser(userId);
+
+    expect(assessment.onChainPermanentData).toBe(true);
+    expect(assessment.standardPaymentOrders).toBe(1);
+  });
+
+  it('ignores free events for on-chain payment assessment', async () => {
+    const eventId = new mongoose.Types.ObjectId();
+
+    (mockTicketOrder.find as jest.Mock).mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          {
+            eventTicket: eventId,
+            paymentPrivacy: null,
+          },
+        ]),
+      }),
+    });
+
+    (mockEventTicket.find as jest.Mock).mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          {
+            _id: eventId,
+            name: 'Free Meetup',
+            eventType: 0,
+            paymentPrivacy: PAYMENT_PRIVACY_STANDARD,
+          },
+        ]),
+      }),
+    });
+
+    const assessment = await ErasureAssessmentService.assessUser(userId);
+
+    expect(assessment.onChainPermanentData).toBe(false);
+    expect(assessment.standardPaymentOrders).toBe(0);
+  });
+});

--- a/tests/erasure-assessment.service.test.ts
+++ b/tests/erasure-assessment.service.test.ts
@@ -157,5 +157,7 @@ describe('ErasureAssessmentService', () => {
 
     expect(assessment.onChainPermanentData).toBe(false);
     expect(assessment.standardPaymentOrders).toBe(0);
+    expect(assessment.ordersReviewed).toBe(0);
+    expect(assessment.anonymousOnlyPaymentHistory).toBe(false);
   });
 });

--- a/tests/payment-privacy-disclosure.service.test.ts
+++ b/tests/payment-privacy-disclosure.service.test.ts
@@ -33,8 +33,10 @@ describe('PaymentPrivacyDisclosureService', () => {
       );
       expect(d.level).toBe('anonymous');
       expect(d.onChainWalletStored).toBe(false);
+      expect(d.onChainDataPermanent).toBe(true);
       expect(d.acknowledgmentRequired).toBe(false);
-      expect(d.warning).toMatch(/not stored/i);
+      expect(d.warning).toMatch(/permanent Soroban PaymentRecord/i);
+      expect(d.warning).toMatch(/wallet address is not stored/i);
     });
   });
 

--- a/tests/payment-privacy-disclosure.service.test.ts
+++ b/tests/payment-privacy-disclosure.service.test.ts
@@ -1,0 +1,69 @@
+import {
+  PaymentPrivacyDisclosureService,
+  PAYMENT_PRIVACY_ANONYMOUS,
+  PAYMENT_PRIVACY_STANDARD,
+} from '../src/services/payment-privacy-disclosure.service';
+
+describe('PaymentPrivacyDisclosureService', () => {
+  describe('buildDisclosure', () => {
+    it('returns not_applicable for free events', () => {
+      const d = PaymentPrivacyDisclosureService.buildDisclosure(0, 1);
+      expect(d.level).toBe('not_applicable');
+      expect(d.acknowledgmentRequired).toBe(false);
+      expect(d.warning).toBeNull();
+    });
+
+    it('requires acknowledgment for Standard paid events', () => {
+      const d = PaymentPrivacyDisclosureService.buildDisclosure(
+        1,
+        PAYMENT_PRIVACY_STANDARD,
+      );
+      expect(d.level).toBe('standard');
+      expect(d.onChainWalletStored).toBe(true);
+      expect(d.onChainDataPermanent).toBe(true);
+      expect(d.acknowledgmentRequired).toBe(true);
+      expect(d.warning).toMatch(/cannot be erased/i);
+      expect(d.warning).toMatch(/wallet address/i);
+    });
+
+    it('does not require acknowledgment for Anonymous paid events', () => {
+      const d = PaymentPrivacyDisclosureService.buildDisclosure(
+        1,
+        PAYMENT_PRIVACY_ANONYMOUS,
+      );
+      expect(d.level).toBe('anonymous');
+      expect(d.onChainWalletStored).toBe(false);
+      expect(d.acknowledgmentRequired).toBe(false);
+      expect(d.warning).toMatch(/not stored/i);
+    });
+  });
+
+  describe('validateAcknowledgment', () => {
+    it('rejects Standard payment without privacyAcknowledged', () => {
+      const err = PaymentPrivacyDisclosureService.validateAcknowledgment(
+        1,
+        PAYMENT_PRIVACY_STANDARD,
+        false,
+      );
+      expect(err).toMatch(/privacyAcknowledged must be true/i);
+    });
+
+    it('allows Standard payment when privacyAcknowledged is true', () => {
+      const err = PaymentPrivacyDisclosureService.validateAcknowledgment(
+        1,
+        PAYMENT_PRIVACY_STANDARD,
+        true,
+      );
+      expect(err).toBeNull();
+    });
+
+    it('allows Anonymous payment without privacyAcknowledged', () => {
+      const err = PaymentPrivacyDisclosureService.validateAcknowledgment(
+        1,
+        PAYMENT_PRIVACY_ANONYMOUS,
+        undefined,
+      );
+      expect(err).toBeNull();
+    });
+  });
+});

--- a/tests/payment-verification.service.test.ts
+++ b/tests/payment-verification.service.test.ts
@@ -27,6 +27,8 @@ const baseEvent = {
   availableTickets: 10,
   offerReceipts: false,
   privacyLevel: 1,
+  eventType: 1,
+  paymentPrivacy: 0,
   allowAnonymous: false,
   requiresVerification: false,
 };
@@ -196,6 +198,100 @@ describe('PaymentVerificationService - privacy enforcement', () => {
       );
 
       expect(mockUser.findById).not.toHaveBeenCalled();
+      expect(result.success).toBe(false);
+      expect(result.message).toBe('Transaction not found on chain');
+    });
+  });
+
+  describe('paymentPrivacy acknowledgment (#127)', () => {
+    it('rejects Standard payment without privacyAcknowledged', async () => {
+      (mockEventTicket.findById as jest.Mock).mockResolvedValue({
+        ...baseEvent,
+        eventType: 1,
+        paymentPrivacy: 1,
+      });
+
+      const result = await PaymentVerificationService.verifyAndIssueTicket(
+        '0xTxHash',
+        '507f1f77bcf86cd799439011',
+        'event123',
+        'General',
+        1,
+        10,
+        undefined,
+        undefined,
+        undefined,
+        false,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/privacyAcknowledged must be true/i);
+    });
+
+    it('proceeds past disclosure check for Standard payment when acknowledged', async () => {
+      const {
+        BlockchainProvider,
+      } = require('../src/provider/blockchain.provider');
+      const blockchain = BlockchainProvider.getInstance();
+      blockchain.fetchTransaction.mockResolvedValue(null);
+
+      (mockEventTicket.findById as jest.Mock).mockResolvedValue({
+        ...baseEvent,
+        eventType: 1,
+        paymentPrivacy: 1,
+      });
+
+      (mockUser.findById as jest.Mock).mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue({ _id: 'user123' }),
+        }),
+      });
+
+      const result = await PaymentVerificationService.verifyAndIssueTicket(
+        '0xTxHash',
+        '507f1f77bcf86cd799439011',
+        'event123',
+        'General',
+        1,
+        10,
+        undefined,
+        undefined,
+        undefined,
+        true,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe('Transaction not found on chain');
+    });
+
+    it('does not require acknowledgment for Anonymous payment events', async () => {
+      const {
+        BlockchainProvider,
+      } = require('../src/provider/blockchain.provider');
+      const blockchain = BlockchainProvider.getInstance();
+      blockchain.fetchTransaction.mockResolvedValue(null);
+
+      (mockEventTicket.findById as jest.Mock).mockResolvedValue({
+        ...baseEvent,
+        eventType: 1,
+        paymentPrivacy: 0,
+      });
+
+      (mockUser.findById as jest.Mock).mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue({ _id: 'user123' }),
+        }),
+      });
+
+      const result = await PaymentVerificationService.verifyAndIssueTicket(
+        '0xTxHash',
+        '507f1f77bcf86cd799439011',
+        'event123',
+        'General',
+        1,
+        10,
+      );
+
       expect(result.success).toBe(false);
       expect(result.message).toBe('Transaction not found on chain');
     });

--- a/tests/privacy-compliance.routes.test.ts
+++ b/tests/privacy-compliance.routes.test.ts
@@ -26,6 +26,18 @@ describe('Privacy compliance routes (#127)', () => {
     expect(res.body.data.matrix.length).toBeGreaterThan(0);
     expect(res.body.data.summary.onChainPermanent).toMatch(/immutable/i);
     expect(res.body.data.summary.offChainErasable).toMatch(/MongoDB/i);
+    expect(res.body.data.summary.policyDocumentPath).toBe(
+      '/compliance/data-retention',
+    );
+  });
+
+  it('GET /compliance/privacy-policy returns user-facing summary', async () => {
+    const res = await request(app).get('/compliance/privacy-policy');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.title).toMatch(/Privacy/i);
+    expect(res.body.data.sections.length).toBeGreaterThanOrEqual(3);
+    expect(res.body.data.sections[1].body).toMatch(/permanent/i);
   });
 
   it('GET /compliance/payment-privacy-disclosure/:eventId returns Standard warning', async () => {

--- a/tests/privacy-compliance.routes.test.ts
+++ b/tests/privacy-compliance.routes.test.ts
@@ -1,0 +1,63 @@
+import request from 'supertest';
+import express from 'express';
+import privacyComplianceRoutes from '../src/routes/privacy-compliance.route';
+import EventTicket from '../src/models/event-ticket';
+import { PAYMENT_PRIVACY_STANDARD } from '../src/services/payment-privacy-disclosure.service';
+
+jest.mock('../src/models/event-ticket');
+
+const mockEventTicket = EventTicket as jest.Mocked<typeof EventTicket>;
+
+const app = express();
+app.use(express.json());
+app.use('/compliance', privacyComplianceRoutes);
+
+describe('Privacy compliance routes (#127)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('GET /compliance/data-retention returns matrix and summary', async () => {
+    const res = await request(app).get('/compliance/data-retention');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(Array.isArray(res.body.data.matrix)).toBe(true);
+    expect(res.body.data.matrix.length).toBeGreaterThan(0);
+    expect(res.body.data.summary.onChainPermanent).toMatch(/immutable/i);
+    expect(res.body.data.summary.offChainErasable).toMatch(/MongoDB/i);
+  });
+
+  it('GET /compliance/payment-privacy-disclosure/:eventId returns Standard warning', async () => {
+    const eventId = '507f1f77bcf86cd799439011';
+
+    (mockEventTicket.findById as jest.Mock).mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue({
+          _id: eventId,
+          name: 'Paid Public Event',
+          eventType: 1,
+          paymentPrivacy: PAYMENT_PRIVACY_STANDARD,
+        }),
+      }),
+    });
+
+    const res = await request(app).get(
+      `/compliance/payment-privacy-disclosure/${eventId}`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.paymentDisclosure.acknowledgmentRequired).toBe(true);
+    expect(res.body.data.paymentDisclosure.warning).toMatch(
+      /cannot be erased/i,
+    );
+  });
+
+  it('GET /compliance/payment-privacy-disclosure/:eventId returns 400 for invalid id', async () => {
+    const res = await request(app).get(
+      '/compliance/payment-privacy-disclosure/not-an-object-id',
+    );
+
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- Document erasable off-chain vs permanent on-chain data in `docs/compliance/data-retention.md` and expose it via `GET /compliance/data-retention`.
- Add pre-payment Standard (`paymentPrivacy=1`) disclosures on event fetch and `GET /compliance/payment-privacy-disclosure/:eventId`; require `privacyAcknowledged: true` before `verify-payment`.
- Add authenticated erasure assessment and off-chain anonymization (`GET/POST /account/*`) plus a daily retention worker for TTL hygiene and stuck jobs.

Closes #127 for GrantFox

## Test plan
- [x] `npm run build`
- [x] `npm test` (175 tests, 29 new for #127)
- [ ] Maintainer approves fork CI workflow
- [ ] Manual: `GET /compliance/data-retention` returns matrix
- [ ] Manual: Standard paid event blocks `verify-payment` without `privacyAcknowledged`
- [ ] Manual: `POST /account/request-erasure` anonymizes profile and reports on-chain impact


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added compliance endpoints for data retention, user-facing privacy policy, and payment privacy disclosures.
  * Added account endpoints for erasure assessment and erasure requests.
  * Introduced scheduled data retention/anonymization processing and retention reporting.
* **Bug Fixes**
  * Enforced privacy acknowledgment during ticket verification (supports boolean/string inputs).
  * Included payment privacy disclosure details in event responses.
* **Documentation**
  * Added a data-retention reference and a user-facing privacy policy.
* **Tests**
  * Added Jest coverage for retention, anonymization, assessments, disclosures, routes, and ticket verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->