### PR TITLE
Fix signup duplicate email race handling

### DIFF
--- a/src/controllers/signup.controller.ts
+++ b/src/controllers/signup.controller.ts
@@ -59,6 +59,11 @@ export const signupController: RequestHandler = async (
         'User registered successfully. Please verify your account with the OTP sent to your email.',
     });
   } catch (error: any) {
-    res.status(500).json({ message: error.message });
+    if (error?.code === 11000) {
+      res.status(400).json({ message: 'Email is already in use' });
+      return;
+    }
+
+    res.status(500).json({ message: 'An error occurred. Please try again.' });
   }
 };

--- a/tests/signup.controller.test.ts
+++ b/tests/signup.controller.test.ts
@@ -73,6 +73,43 @@ describe('signup controller', () => {
     });
   });
 
+  it('returns 400 without leaking database details when save hits duplicate key', async () => {
+    (User.findOne as jest.Mock).mockResolvedValue(null);
+    (User as unknown as jest.Mock).mockImplementationOnce(function (
+      this: any,
+      data: any,
+    ) {
+      Object.assign(this, data);
+      this.save = jest.fn().mockRejectedValue({
+        code: 11000,
+        message:
+          'E11000 duplicate key error collection: zicket.users index: email_1 dup key',
+      });
+      return this;
+    });
+
+    const req = {
+      body: {
+        name: 'Race User',
+        email: 'race@example.com',
+        password: 'secret123',
+      },
+    };
+    const res = createResponse();
+    await signupController(req as any, res as any, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Email is already in use',
+    });
+    expect(res.json).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('E11000'),
+      }),
+    );
+    expect(mockSendVerificationOtp).not.toHaveBeenCalled();
+  });
+
   it('creates user with OTP and sends verification email', async () => {
     (User.findOne as jest.Mock).mockResolvedValue(null);
 


### PR DESCRIPTION
## Summary
- handle MongoDB duplicate key errors during signup with a friendly 400 response
- avoid leaking raw database error messages from the signup controller
- add regression coverage for the concurrent duplicate-email save path

## Tests
- npm test -- tests/signup.controller.test.ts --runInBand
- npm run build

Fixes #141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sign-up now shows a clear “Email is already in use” message when a duplicate email is detected.
  * Other unexpected sign-up errors now return a generic, user-friendly message instead of exposing technical details.
  * Added coverage to ensure duplicate-email cases stop the verification step and return the correct response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->