### PR TITLE
fix: add adminGuard to message center routes

### DIFF
--- a/src/routes/message-center.route.ts
+++ b/src/routes/message-center.route.ts
@@ -6,17 +6,19 @@ import {
   editMessage,
   deleteMessage,
 } from '../controllers/message-center.controller';
-import { authGuard } from '../middlewares/auth';
+import { authGuard, adminGuard } from '../middlewares/auth';
 
 const messageCenterRoutes = Router();
 
-messageCenterRoutes.delete('/:messageId', authGuard, deleteMessage);
-messageCenterRoutes.post('/', authGuard, sendMessage);
-messageCenterRoutes.get('/past', authGuard, getPastMessages);
-messageCenterRoutes.get('/scheduled', authGuard, getScheduledMessages);
-messageCenterRoutes.patch('/:messageId', authGuard, editMessage);
-
-messageCenterRoutes.get('/past', authGuard, getPastMessages);
-messageCenterRoutes.get('/scheduled', authGuard, getScheduledMessages);
+messageCenterRoutes.post('/', authGuard, adminGuard, sendMessage);
+messageCenterRoutes.delete('/:messageId', authGuard, adminGuard, deleteMessage);
+messageCenterRoutes.get('/past', authGuard, adminGuard, getPastMessages);
+messageCenterRoutes.get(
+  '/scheduled',
+  authGuard,
+  adminGuard,
+  getScheduledMessages,
+);
+messageCenterRoutes.patch('/:messageId', authGuard, adminGuard, editMessage);
 
 export default messageCenterRoutes;

--- a/src/utils/nullifier-bytes.ts
+++ b/src/utils/nullifier-bytes.ts
@@ -13,17 +13,6 @@ export function nullifierToCanonicalHex(nullifier: string): string {
   }
   return hex.padStart(64, '0');
 }
-export function nullifierToCanonicalHex(nullifier: string): string {
-  const value = BigInt(nullifier);
-  if (value < 0n) {
-    throw new Error('Nullifier must be non-negative');
-  }
-  const hex = value.toString(16);
-  if (hex.length > 64) {
-    throw new Error('Nullifier exceeds 32 bytes');
-  }
-  return hex.padStart(64, '0');
-}
 
 /**
  * Converts a zkPassport nullifier public signal to a 32-byte buffer for Soroban BytesN<32>.

--- a/tests/message-center.route.auth.test.ts
+++ b/tests/message-center.route.auth.test.ts
@@ -1,0 +1,116 @@
+import request from 'supertest';
+import app from '../src/app';
+import { JwtVerify } from '../src/middlewares/jwt';
+import User from '../src/models/user';
+
+jest.mock('../src/middlewares/jwt');
+jest.mock('../src/models/user');
+
+const VALID_ID = '65f9f9e4c51058f58d05d9aa';
+
+describe('Message center route — authentication & authorization guards', () => {
+  describe('unauthenticated requests (no token)', () => {
+    const protectedRoutes: Array<{
+      method: 'post' | 'get' | 'patch' | 'delete';
+      path: string;
+    }> = [
+      { method: 'post', path: '/zk-message-center' },
+      { method: 'get', path: '/zk-message-center/past' },
+      { method: 'get', path: '/zk-message-center/scheduled' },
+      { method: 'patch', path: `/zk-message-center/${VALID_ID}` },
+      { method: 'delete', path: `/zk-message-center/${VALID_ID}` },
+    ];
+
+    it.each(protectedRoutes)(
+      '$method $path returns 401 without Authorization header',
+      async ({ method, path }) => {
+        const res = await (request(app) as any)[method](path).send({});
+        expect(res.status).toBe(401);
+        expect(res.body).toMatchObject({
+          error: expect.stringContaining('Unauthorized'),
+        });
+      },
+    );
+  });
+
+  describe('authenticated non-admin requests', () => {
+    beforeEach(() => {
+      (JwtVerify as jest.Mock).mockReturnValue({
+        id: 'user-id-1',
+        email: 'user@example.com',
+      });
+      (User.findById as jest.Mock).mockResolvedValue({
+        _id: 'user-id-1',
+        email: 'user@example.com',
+        provider: 'local',
+        emailVerifiedAt: new Date(),
+        role: 'user',
+      });
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    const protectedRoutes: Array<{
+      method: 'post' | 'get' | 'patch' | 'delete';
+      path: string;
+    }> = [
+      { method: 'post', path: '/zk-message-center' },
+      { method: 'get', path: '/zk-message-center/past' },
+      { method: 'get', path: '/zk-message-center/scheduled' },
+      { method: 'patch', path: `/zk-message-center/${VALID_ID}` },
+      { method: 'delete', path: `/zk-message-center/${VALID_ID}` },
+    ];
+
+    it.each(protectedRoutes)(
+      '$method $path returns 403 for non-admin user',
+      async ({ method, path }) => {
+        const res = await (request(app) as any)
+          [method](path)
+          .set('Authorization', 'Bearer valid.token')
+          .send({});
+        expect(res.status).toBe(403);
+        expect(res.body).toMatchObject({
+          error: 'Forbidden: Admin access required',
+        });
+      },
+    );
+  });
+
+  describe('authenticated admin requests', () => {
+    beforeEach(() => {
+      (JwtVerify as jest.Mock).mockReturnValue({
+        id: 'admin-id-1',
+        email: 'admin@example.com',
+      });
+      (User.findById as jest.Mock).mockResolvedValue({
+        _id: 'admin-id-1',
+        email: 'admin@example.com',
+        provider: 'local',
+        emailVerifiedAt: new Date(),
+        role: 'admin',
+      });
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('GET /zk-message-center/past passes auth and admin guards', async () => {
+      const res = await request(app)
+        .get('/zk-message-center/past')
+        .set('Authorization', 'Bearer admin.token');
+      expect(res.status).not.toBe(401);
+      expect(res.status).not.toBe(403);
+    }, 15000);
+
+    it('GET /zk-message-center/scheduled passes auth and admin guards', async () => {
+      const res = await request(app)
+        .get('/zk-message-center/scheduled')
+        .set('Authorization', 'Bearer admin.token');
+      expect(res.status).not.toBe(401);
+      expect(res.status).not.toBe(403);
+    }, 15000);
+  });
+});


### PR DESCRIPTION
## Description

Fixes broken access control in the Message Center. All endpoints (create, read, update, delete) were only protected by `authGuard`, allowing any authenticated user to manage platform-wide messages. This adds the existing `adminGuard` middleware to restrict access to admins only.

## Changes

1. **`src/routes/message-center.route.ts`** — Added `adminGuard` after `authGuard` on all 5 endpoints. Removed duplicate route registrations.

2. **`tests/message-center.route.auth.test.ts`** (new) — 12 integration tests verifying:
   - Unauthenticated requests → 401
   - Authenticated non-admin users → 403 Forbidden: Admin access required
   - Authenticated admin users → pass both guards

3. **`src/utils/nullifier-bytes.ts`** — Fixed pre-existing duplicate function declaration that broke all test suites.

## Verification

- All 38 message center tests pass (4 test suites)
- `prettier` formatting passes

Closes #133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Message Center routes now consistently require both sign-in and admin access, preventing duplicate route handling and tightening access to scheduled and past messages.
  * Existing input conversion behavior remains unchanged.

* **Tests**
  * Added coverage to verify Message Center access rules for unauthenticated users, non-admin users, and admins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->